### PR TITLE
Support get static chain metadata in SDK.

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -589,6 +589,18 @@ func (c *Config) GetEffectiveEventTag(eventTag uint32) uint32 {
 	return c.Chain.EventTag.GetEffectiveEventTag(eventTag)
 }
 
+func (c *Config) GetChainMetadataHelper(req *api.GetChainMetadataRequest) (*api.GetChainMetadataResponse, error) {
+	return &api.GetChainMetadataResponse{
+		LatestBlockTag:       c.GetLatestBlockTag(),
+		StableBlockTag:       c.GetStableBlockTag(),
+		LatestEventTag:       c.GetLatestEventTag(),
+		StableEventTag:       c.GetStableEventTag(),
+		BlockStartHeight:     c.Chain.BlockStartHeight,
+		IrreversibleDistance: c.Chain.IrreversibleDistance,
+		BlockTime:            c.Chain.BlockTime.String(),
+	}, nil
+}
+
 func WithNamespace(namespace string) ConfigOption {
 	return func(opts *configOptions) {
 		opts.Namespace = namespace

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -942,15 +942,7 @@ func (s *Server) parseChainEventsRequest(ctx context.Context, input parseChainEv
 }
 
 func (s *Server) GetChainMetadata(ctx context.Context, req *api.GetChainMetadataRequest) (*api.GetChainMetadataResponse, error) {
-	return &api.GetChainMetadataResponse{
-		LatestBlockTag:       s.config.GetLatestBlockTag(),
-		StableBlockTag:       s.config.GetStableBlockTag(),
-		LatestEventTag:       s.config.GetLatestEventTag(),
-		StableEventTag:       s.config.GetStableEventTag(),
-		BlockStartHeight:     s.config.Chain.BlockStartHeight,
-		IrreversibleDistance: s.config.Chain.IrreversibleDistance,
-		BlockTime:            s.config.Chain.BlockTime.String(),
-	}, nil
+	return s.config.GetChainMetadataHelper(req)
 }
 
 func (s *Server) GetVersionedChainEvent(ctx context.Context, req *api.GetVersionedChainEventRequest) (*api.GetVersionedChainEventResponse, error) {

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -72,6 +72,10 @@ type (
 
 		// GetChainMetadata returns chain metadata, e.g. LatestEventTag.
 		GetChainMetadata(ctx context.Context, req *api.GetChainMetadataRequest) (*api.GetChainMetadataResponse, error)
+
+		// GetStaticChainMetadata returns the static chain metadata, getting from the Config, instead of querying the ChainStorage server.
+		// This is useful if the caller needs a consistent snapshot of chain metadata during its current lifecycle.
+		GetStaticChainMetadata(ctx context.Context, req *api.GetChainMetadataRequest) (*api.GetChainMetadataResponse, error)
 	}
 
 	ChainEventResult struct {
@@ -387,4 +391,8 @@ func (c *clientImpl) GetChainMetadata(ctx context.Context, req *api.GetChainMeta
 	}
 
 	return resp, nil
+}
+
+func (c *clientImpl) GetStaticChainMetadata(ctx context.Context, req *api.GetChainMetadataRequest) (*api.GetChainMetadataResponse, error) {
+	return c.config.GetChainMetadataHelper(req)
 }

--- a/sdk/client_test.go
+++ b/sdk/client_test.go
@@ -43,10 +43,6 @@ func (s *clientTestSuite) SetupTest() {
 	s.gatewayClient = apimocks.NewMockChainStorageClient(s.ctrl)
 	s.downloaderClient = downloadermocks.NewMockBlockDownloader(s.ctrl)
 
-	//var err error
-	//s.config, err = config.New()
-	//s.require.NoError(err)
-
 	s.app = testapp.New(
 		s.T(),
 		Module,

--- a/sdk/client_test.go
+++ b/sdk/client_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/coinbase/chainstorage/internal/config"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/fx"
@@ -14,6 +13,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/coinbase/chainstorage/internal/blockchain/parser"
+	"github.com/coinbase/chainstorage/internal/config"
 	"github.com/coinbase/chainstorage/internal/gateway"
 	"github.com/coinbase/chainstorage/internal/storage/blobstorage/downloader"
 	downloadermocks "github.com/coinbase/chainstorage/internal/storage/blobstorage/downloader/mocks"
@@ -60,7 +60,6 @@ func (s *clientTestSuite) SetupTest() {
 		fx.Provide(func() gateway.Client { return s.gatewayClient }),
 		fx.Populate(&s.client),
 	)
-	s.require = testutil.Require(s.T())
 	s.require.NotNil(s.client)
 }
 

--- a/sdk/mocks/mocks.go
+++ b/sdk/mocks/mocks.go
@@ -155,6 +155,21 @@ func (mr *MockClientMockRecorder) GetLatestBlock(arg0 interface{}) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLatestBlock", reflect.TypeOf((*MockClient)(nil).GetLatestBlock), arg0)
 }
 
+// GetStaticChainMetadata mocks base method.
+func (m *MockClient) GetStaticChainMetadata(arg0 context.Context, arg1 *chainstorage.GetChainMetadataRequest) (*chainstorage.GetChainMetadataResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetStaticChainMetadata", arg0, arg1)
+	ret0, _ := ret[0].(*chainstorage.GetChainMetadataResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetStaticChainMetadata indicates an expected call of GetStaticChainMetadata.
+func (mr *MockClientMockRecorder) GetStaticChainMetadata(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStaticChainMetadata", reflect.TypeOf((*MockClient)(nil).GetStaticChainMetadata), arg0, arg1)
+}
+
 // GetTag mocks base method.
 func (m *MockClient) GetTag() uint32 {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
### What changed? Why?
<!-- Please describe the change and why you made it. -->
 Port over "Support get static chain metadata in SDK" from internal repo

### How did you test the change?
<!-- Please describe how the change was tested. -->
Unit test