### PR TITLE
feat: run tests in GitHub Actions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,33 @@
+name: ChainStorage CI
+on: [push]
+concurrency:
+  group: "ci-${{ github.ref_name }}"
+  cancel-in-progress: true
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: "Setup environment"
+        uses: ./.github/workflows/setup
+      - name: Build
+        run: make build
+  test:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: "Setup environment"
+        uses: ./.github/workflows/setup
+      - name: Build
+        run: make test
+  integration:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: "Setup environment"
+        uses: ./.github/workflows/setup
+      - name: Build
+        run: make integration

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,8 +29,20 @@ jobs:
         uses: actions/checkout@v3
       - name: "Setup environment"
         uses: ./.github/workflows/setup
-      - name: Integration Tests
+      - name: Run localstack
         shell: bash
         run: |
           docker compose -f docker-compose-testing.yml up -d --force-recreate
-          make integration
+          echo "Waiting for localstack to be ready..."
+          for i in $(seq 1 999); do
+            if [ "$(curl -s http://localhost:4566/_localstack/health | jq -r '.services.s3')" = "available" ]; then
+              break
+            fi
+            sleep 0.3
+            if [ $(($i % 30)) -eq 0 ]; then
+              echo .
+            fi 
+          done
+          echo "localstack ready"
+      - name: Integration Tests
+        run: make integration

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v3
       - name: "Setup environment"
         uses: ./.github/workflows/setup
-      - name: Build
+      - name: Test
         run: make test
   integration:
     runs-on: ubuntu-22.04
@@ -29,5 +29,8 @@ jobs:
         uses: actions/checkout@v3
       - name: "Setup environment"
         uses: ./.github/workflows/setup
-      - name: Build
-        run: make integration
+      - name: Integration Tests
+        shell: bash
+        run: |
+          docker compose -f docker-compose-testing.yml up -d --force-recreate
+          make integration

--- a/.github/workflows/setup/action.yaml
+++ b/.github/workflows/setup/action.yaml
@@ -1,0 +1,18 @@
+name: "Setup"
+description: "setup environment"
+runs:
+  using: "composite"
+  steps:
+    - name: Set up go
+      uses: actions/setup-go@v4
+      with:
+        go-version: 1.21.2
+    - name: Install asdf & tools
+      uses: asdf-vm/actions/setup@v2
+    - name: Setup
+      shell: bash
+      run: |
+        asdf plugin-add protoc https://github.com/paxosglobal/asdf-protoc.git
+        asdf install protoc 24.4
+        asdf global protoc 24.4
+        make bootstrap

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -10,7 +10,6 @@ services:
     ports:
       - 4566:4566
     environment:
-      - SERVICES=s3,dynamodb,sqs
       - DEBUG=1
       - DOCKER_HOST=unix:///var/run/docker.sock
       - AWS_DEFAULT_REGION=us-east-1

--- a/docker-compose-testing.yml
+++ b/docker-compose-testing.yml
@@ -1,8 +1,8 @@
-version: '3'
+version: "3"
 
 services:
   localstack:
-    image: localstack/localstack:0.11.6
+    image: localstack/localstack:2.3.2
     ports:
       - 4566:4566
     environment:
@@ -14,4 +14,3 @@ services:
       - AWS_SECRET_ACCESS_KEY=requirednotused
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - ./bin/localstack:/docker-entrypoint-i

--- a/docker-compose-testing.yml
+++ b/docker-compose-testing.yml
@@ -6,7 +6,6 @@ services:
     ports:
       - 4566:4566
     environment:
-      - SERVICES=s3,dynamodb,sqs
       - DEBUG=1
       - DOCKER_HOST=unix:///var/run/docker.sock
       - AWS_DEFAULT_REGION=us-east-1


### PR DESCRIPTION
### What changed? Why?
<!-- Please describe the change and why you made it. -->

+ Setup GitHub Actions to run `make build`, `make tests`, and `make integration`
+ Use localstack 2.3.2 to run `make integration`
+ Setup cache for go build
+ Setup dependabot for GitHub Actions
 
### How did you test the change?
<!-- Please describe how the change was tested. -->

https://github.com/bestmike007/chainstorage/actions/runs/6479456128
