### PR TITLE
chore: remove downloader from blob storage module

### DIFF
--- a/internal/storage/blobstorage/module.go
+++ b/internal/storage/blobstorage/module.go
@@ -2,11 +2,8 @@ package blobstorage
 
 import (
 	"go.uber.org/fx"
-
-	"github.com/coinbase/chainstorage/internal/storage/blobstorage/downloader"
 )
 
 var Module = fx.Options(
 	fx.Provide(New),
-	downloader.Module,
 )


### PR DESCRIPTION
### What changed? Why?
<!-- Please describe the change and why you made it. -->
 
The blob storage is not depending on block downloader.

### How did you test the change?
<!-- Please describe how the change was tested. -->

GitHub Actions.