### PR TITLE
feat: run ci with recent go versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,29 +9,50 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        go-version:
+          - "1.21"
+          - "1.20"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: "Setup environment"
         uses: ./.github/workflows/setup
+        with:
+          go-version: ${{ matrix.go-version }}
       - name: Build
         run: make build
   test:
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        go-version:
+          - "1.21"
+          - "1.20"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: "Setup environment"
         uses: ./.github/workflows/setup
+        with:
+          go-version: ${{ matrix.go-version }}
       - name: Test
         run: make test
   integration:
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        go-version:
+          - "1.21"
+          - "1.20"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: "Setup environment"
         uses: ./.github/workflows/setup
+        with:
+          go-version: ${{ matrix.go-version }}
       - name: Run localstack
         shell: bash
         run: |

--- a/.github/workflows/setup/action.yaml
+++ b/.github/workflows/setup/action.yaml
@@ -1,12 +1,17 @@
 name: "Setup"
 description: "setup environment"
+inputs:
+  go-version:
+    description: 'Golang version to use'
+    required: false
+    default: '1.21'
 runs:
   using: "composite"
   steps:
     - name: Set up go
       uses: actions/setup-go@v4
       with:
-        go-version: 1.21.3
+        go-version: ${{ inputs.go-version }}
     - name: Install asdf & tools
       uses: asdf-vm/actions/setup@v2
     - name: Setup


### PR DESCRIPTION
### What changed? Why?
<!-- Please describe the change and why you made it. -->

Run build, test, and integration with recent golang versions including 1.20 and 1.21.

Note: yq requires 1.20+
 
### How did you test the change?
<!-- Please describe how the change was tested. -->

+ GitHub Actions
