### PR TITLE
adding rate limiting function to blockchain client

### DIFF
--- a/internal/blockchain/endpoints/endpoint_provider.go
+++ b/internal/blockchain/endpoints/endpoint_provider.go
@@ -259,6 +259,10 @@ func newEndpoint(
 		opts = append(opts, withOverrideRequestTimeout(cfg.Chain.Client.HttpTimeout))
 	}
 
+	if endpoint.RPS > 0 {
+		opts = append(opts, withRPS(endpoint.RPS))
+	}
+
 	client, err := newHTTPClient(opts...)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to create http client for %v: %w", endpoint.Name, err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -296,6 +296,7 @@ type (
 		Password   string            `json:"password"`
 		Weight     uint8             `json:"weight"`
 		ExtraUrls  map[string]string `json:"extra_urls"`
+		RPS        int               `json:"rps"`
 	}
 
 	EndpointConfig struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -401,6 +401,7 @@ func TestEndpointParsing(t *testing.T) {
 				User:     "testUser",
 				Password: "testPassword",
 				Weight:   1,
+				RPS:      0,
 			},
 		},
 		EndpointConfig: config.EndpointConfig{
@@ -550,6 +551,22 @@ func TestEndpointGroup(t *testing.T) {
 						User:     "foo",
 						Password: "bar",
 						Weight:   4,
+					},
+				},
+				UseFailover: false,
+			},
+		},
+		{
+			fixture: "non_zero_rps",
+			expected: config.EndpointGroup{
+				Endpoints: []config.Endpoint{
+					{
+						Name:     "chain-storage-eth-04",
+						Url:      "https://254c3b9c-be59-41c3-8f6f-3cc3342c7b3c.ethereum.bison.run",
+						User:     "foo",
+						Password: "bar",
+						Weight:   4,
+						RPS:      100,
 					},
 				},
 				UseFailover: false,

--- a/internal/utils/fixtures/config/endpoint_group/non_zero_rps.json
+++ b/internal/utils/fixtures/config/endpoint_group/non_zero_rps.json
@@ -1,0 +1,12 @@
+{
+  "endpoints": [
+    {
+      "name": "chain-storage-eth-04",
+      "url": "https://254c3b9c-be59-41c3-8f6f-3cc3342c7b3c.ethereum.bison.run",
+      "user": "foo",
+      "password": "bar",
+      "weight": 4,
+      "rps": 100
+    }
+  ]
+}

--- a/internal/utils/ratelimiter/rate_limiter.go
+++ b/internal/utils/ratelimiter/rate_limiter.go
@@ -1,6 +1,7 @@
 package ratelimiter
 
 import (
+	"context"
 	"time"
 
 	"golang.org/x/time/rate"
@@ -14,7 +15,7 @@ type (
 
 // New returns a new Limiter that allows events up to r requests per second.
 func New(rps int) *RateLimiter {
-	if rps == 0 {
+	if rps <= 0 {
 		// Unlimited
 		return nil
 	}
@@ -43,6 +44,15 @@ func (l *RateLimiter) AllowN(n int) bool {
 	}
 
 	return l.limiter.AllowN(time.Now(), n)
+}
+
+// WaitN blocks until it permits n events to happen
+func (l *RateLimiter) WaitN(ctx context.Context, n int) (err error) {
+	if l == nil {
+		return nil
+	}
+
+	return l.limiter.WaitN(ctx, n)
 }
 
 // Limit returns the maximum overall event rate.


### PR DESCRIPTION
### What changed? Why?
adding rate limiting function to blockchain client
 
### How did you test the change?
<!-- Please describe how the change was tested. -->
- [x] unit test
- [x] integration test
- [ ] functional test
- [x] adhoc test (described below)
- [x] ran admin command to get block from node and backfill blocks
