### PR TITLE
make tlsconfig enabled not required

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -154,8 +154,8 @@ type (
 	}
 
 	CadenceTLSConfig struct {
-		Enabled              bool   `mapstructure:"enabled" validate:"required"`
-		ValidateHostname     bool   `mapstructure:"validate_hostname" validate:"required"`
+		Enabled              bool   `mapstructure:"enabled"`
+		ValidateHostname     bool   `mapstructure:"validate_hostname"`
 		CertificateAuthority string `mapstructure:"certificate_authority"`
 		ClientCertificate    string `mapstructure:"client_certificate"`
 		ClientPrivateKey     string `mapstructure:"client_private_key"`


### PR DESCRIPTION
### What changed? Why?
make tlsconfig enabled not required otherwise there is no way to turn it off
 
### How did you test the change?
<!-- Please describe how the change was tested. -->
- [x] unit test
- [ ] integration test
- [ ] functional test
- [ ] adhoc test (described below)
