### PR TITLE
separate aws name checks to separate test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,11 @@ docker-build:
 	@echo "--- docker-build"
 	docker build -t coinbase/chainstorage .
 
+.PHONY: validate-configs
+validate-configs:
+	@echo "--- validate-config"
+	TEST_TYPE=unit go test ./internal/config -run=TestConfig$
+
 .PHONY: test
 test: fmt lint
 	@echo "--- test"

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ docker-build:
 .PHONY: validate-configs
 validate-configs:
 	@echo "--- validate-config"
-	TEST_TYPE=unit go test ./internal/config -run=TestConfig$
+	TEST_TYPE=unit go test ./internal/config -run=TestValidateConfigs$
 
 .PHONY: test
 test: fmt lint


### PR DESCRIPTION
### What changed? Why?
separate aws name checks to separate test
then you can run the following test only to validate configs
```
make validate-configs
```
 
### How did you test the change?
<!-- Please describe how the change was tested. -->
- [x] unit test
- [ ] integration test
- [ ] functional test
- [ ] adhoc test (described below)

automerge=true