### PR TITLE
add config path override

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,7 +19,6 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/config"
-	"github.com/coinbase/chainstorage/internal/utils/consts"
 	"github.com/coinbase/chainstorage/internal/utils/utils"
 	"github.com/coinbase/chainstorage/protos/coinbase/c3/common"
 	api "github.com/coinbase/chainstorage/protos/coinbase/chainstorage"
@@ -457,6 +456,8 @@ const (
 	EnvVarNamespace   = "CHAINSTORAGE_NAMESPACE"
 	EnvVarConfigName  = "CHAINSTORAGE_CONFIG"
 	EnvVarEnvironment = "CHAINSTORAGE_ENVIRONMENT"
+	EnvVarConfigRoot  = "CHAINSTORAGE_CONFIG_ROOT"
+	EnvVarConfigPath  = "CHAINSTORAGE_CONFIG_PATH"
 	EnvVarTestType    = "TEST_TYPE"
 	EnvVarCI          = "CI"
 
@@ -610,12 +611,12 @@ func getConfigName() string {
 	return configName
 }
 
-func GetProjectName() string {
-	projectName, ok := os.LookupEnv("CODEFLOW_PROJECT_NAME")
-	if !ok {
-		projectName = consts.ProjectName
-	}
-	return projectName
+func GetConfigRoot() string {
+	return os.Getenv(EnvVarConfigRoot)
+}
+
+func GetConfigPath() string {
+	return os.Getenv(EnvVarConfigPath)
 }
 
 func mergeInConfig(v *viper.Viper, configOpts *configOptions, env Env) error {
@@ -850,17 +851,22 @@ func getConfigData(namespace string, env Env, blockchain common.Blockchain, netw
 	networkName := strings.TrimPrefix(network.GetName(), blockchainName+"-")
 	sidechainName := strings.TrimPrefix(sidechain.GetName(), blockchainName+"-"+networkName+"-")
 
+	configRoot := GetConfigRoot()
 	if env == envSecrets {
 		// .secrets.yml is intentionally not embedded in config.Store.
 		// Read it from the file system instead.
-		_, filename, _, ok := runtime.Caller(0)
-		if !ok {
-			return nil, xerrors.Errorf("failed to recover the filename information")
+		// If configRoot is not set, use the default path.
+		if len(configRoot) == 0 {
+			_, filename, _, ok := runtime.Caller(0)
+			if !ok {
+				return nil, xerrors.Errorf("failed to recover the filename information")
+			}
+			rootDir := strings.TrimSuffix(filename, CurrentFileName)
+			configRoot = fmt.Sprintf("%v/config", rootDir)
 		}
-		rootDir := strings.TrimSuffix(filename, CurrentFileName)
-		configPath := fmt.Sprintf("%v/config/%v/%v/%v/.secrets.yml", rootDir, namespace, blockchainName, networkName)
+		configPath := fmt.Sprintf("%v/%v/%v/%v/.secrets.yml", configRoot, namespace, blockchainName, networkName)
 		if sidechain != api.SideChain_SIDECHAIN_NONE {
-			configPath = fmt.Sprintf("%v/config/%v/%v/%v/%v/.secrets.yml", rootDir, namespace, blockchainName, networkName, sidechainName)
+			configPath = fmt.Sprintf("%v/%v/%v/%v/%v/.secrets.yml", configRoot, namespace, blockchainName, networkName, sidechainName)
 		}
 		reader, err := os.Open(configPath)
 		if err != nil {
@@ -869,7 +875,26 @@ func getConfigData(namespace string, env Env, blockchain common.Blockchain, netw
 		return reader, nil
 	}
 
-	configPath := fmt.Sprintf("%v/%v/%v/%v.yml", namespace, blockchainName, networkName, env)
+	configPath := GetConfigPath()
+	// If configPath is not set, try to construct the file system path from configRoot.
+	if len(configPath) == 0 && len(configRoot) > 0 {
+		configPath = fmt.Sprintf("%v/%v/%v/%v/%v.yml", configRoot, namespace, blockchainName, networkName, env)
+		if sidechain != api.SideChain_SIDECHAIN_NONE {
+			configPath = fmt.Sprintf("%v/%v/%v/%v/%v/%v.yml", configRoot, namespace, blockchainName, networkName, sidechainName, env)
+		}
+	}
+
+	// If either configRoot or configPath is set, read the config from the file system.
+	if len(configPath) > 0 {
+		reader, err := os.Open(configPath)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to read config file %v: %w", configPath, err)
+		}
+		return reader, nil
+	}
+
+	// Read the config from the embedded config.Store.
+	configPath = fmt.Sprintf("%v/%v/%v/%v.yml", namespace, blockchainName, networkName, env)
 	if sidechain != api.SideChain_SIDECHAIN_NONE {
 		configPath = fmt.Sprintf("%v/%v/%v/%v/%v.yml", namespace, blockchainName, networkName, sidechainName, env)
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -400,7 +400,7 @@ func TestConfigOverridingByEnvSettings(t *testing.T) {
 
 func TestConfigOverrideConfigPath(t *testing.T) {
 	require := testutil.Require(t)
-	err := os.Setenv(config.EnvVarConfigPath, "config/chainstorage/ethereum/mainnet/base.yml")
+	err := os.Setenv(config.EnvVarConfigPath, "../../config/chainstorage/ethereum/mainnet/base.yml")
 	require.NoError(err)
 	defer os.Unsetenv(config.EnvVarConfigPath)
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -398,6 +398,19 @@ func TestConfigOverridingByEnvSettings(t *testing.T) {
 	})
 }
 
+func TestConfigOverrideConfigPath(t *testing.T) {
+	require := testutil.Require(t)
+	err := os.Setenv(config.EnvVarConfigPath, "config/chainstorage/ethereum/mainnet/base.yml")
+	require.NoError(err)
+	defer os.Unsetenv(config.EnvVarConfigPath)
+
+	cfg, err := config.New()
+	require.NoError(err)
+
+	require.Equal(common.Blockchain_BLOCKCHAIN_ETHEREUM, cfg.Blockchain())
+	require.Equal(common.Network_NETWORK_ETHEREUM_MAINNET, cfg.Network())
+}
+
 func TestEndpointParsing(t *testing.T) {
 	require := testutil.Require(t)
 


### PR DESCRIPTION
### What changed? Why?
Add 2 env var overrides that allows for loading the config from file.
* CHAINSTORAGE_CONFIG_ROOT specifies the file directory path where config directory is located.  This allow loading the config for different networks for admins
* CHAINSTORAGE_CONFIG_PATH specifies the file path for the config file to load.  This allow loading a specific config file for the current server or worker.

<!-- Please describe the change and why you made it. -->
 
### How did you test the change?
<!-- Please describe how the change was tested. -->
- [X] unit test
- [ ] integration test
- [ ] functional test
- [ ] adhoc test (described below)
