### PR TITLE
add gcs module, this fixes the initialization chainstorage

### DIFF
--- a/internal/storage/blobstorage/module.go
+++ b/internal/storage/blobstorage/module.go
@@ -1,6 +1,7 @@
 package blobstorage
 
 import (
+	"github.com/coinbase/chainstorage/internal/storage/blobstorage/gcs"
 	"go.uber.org/fx"
 
 	"github.com/coinbase/chainstorage/internal/storage/blobstorage/internal"
@@ -16,4 +17,5 @@ type (
 var Module = fx.Options(
 	fx.Provide(internal.WithBlobStorageFactory),
 	s3.Module,
+	gcs.Module,
 )


### PR DESCRIPTION
### What changed? Why?
This fixes the following error whenever we try to start chainstorage.
`
failed to build internal.BlobStorage:\nmissing dependencies for function \"[github.com/coinbase/chainstorage/internal/storage/blobstorage/internal\](http://github.com/coinbase/chainstorage/internal/storage/blobstorage/internal%5C)".WithBlobStorageFactory\n\t/app/internal/storage/blobstorage/internal/blobstorage.go:32:\nmissing type:\n\t- internal.BlobStorageFactory[name=\"blobstorage/gcs\"] (did you mean to Provide it?)`
 
### How did you test the change?
<!-- Please describe how the change was tested. -->
- [ ] unit test
- [ ] integration test
- [ ] functional test
- [ ] adhoc test (described below)
