### PR TITLE
chore: fix gcs signed url for block

### DIFF
--- a/internal/storage/blobstorage/gcs/blob_storage.go
+++ b/internal/storage/blobstorage/gcs/blob_storage.go
@@ -235,6 +235,7 @@ func (s *blobStorageImpl) Download(ctx context.Context, metadata *api.BlockMetad
 func (s *blobStorageImpl) PreSign(ctx context.Context, objectKey string) (string, error) {
 	fileUrl, err := s.client.Bucket(s.bucket).SignedURL(objectKey, &storage.SignedURLOptions{
 		Expires: time.Now().Add(s.presignedUrlExpiration),
+		Method:  "GET",
 	})
 	if err != nil {
 		return "", xerrors.Errorf("failed to generate presigned url: %w", err)


### PR DESCRIPTION
### What changed? Why?
<!-- Please describe the change and why you made it. -->

HTTP Method for signed url is optional for emulators but required for GCS production env.
 
### How did you test the change?
<!-- Please describe how the change was tested. -->

+ GitHub Actions
+ grpcurl coinbase.chainstorage.ChainStorage/GetBlockFilesByRange
