### PR TITLE
feat: avoid compressing block data in replicator

### DIFF
--- a/internal/storage/blobstorage/gcs/blob_storage.go
+++ b/internal/storage/blobstorage/gcs/blob_storage.go
@@ -22,6 +22,7 @@ import (
 	"github.com/coinbase/chainstorage/internal/utils/fxparams"
 	"github.com/coinbase/chainstorage/internal/utils/instrument"
 	"github.com/coinbase/chainstorage/internal/utils/log"
+	"github.com/coinbase/chainstorage/protos/coinbase/c3/common"
 	api "github.com/coinbase/chainstorage/protos/coinbase/chainstorage"
 )
 
@@ -105,77 +106,99 @@ func New(params BlobStorageParams) (internal.BlobStorage, error) {
 	}, nil
 }
 
+func (s *blobStorageImpl) getObjectKey(blockchain common.Blockchain, sidechain api.SideChain, network common.Network, metadata *api.BlockMetadata, compression api.Compression) (string, error) {
+	var key string
+	var err error
+	blockchainNetwork := fmt.Sprintf("%s/%s", blockchain, network)
+	tagHeightHash := fmt.Sprintf("%d/%d/%s", metadata.Tag, metadata.Height, metadata.Hash)
+	if s.config.Chain.Sidechain != api.SideChain_SIDECHAIN_NONE {
+		key = fmt.Sprintf(
+			"%s/%s/%s", blockchainNetwork, sidechain, tagHeightHash,
+		)
+	} else {
+		key = fmt.Sprintf(
+			"%s/%s", blockchainNetwork, tagHeightHash,
+		)
+	}
+	key, err = storage_utils.GetObjectKey(key, compression)
+	if err != nil {
+		return "", xerrors.Errorf("failed to get object key: %w", err)
+	}
+	return key, nil
+}
+
+func (s *blobStorageImpl) uploadRaw(ctx context.Context, blockchain common.Blockchain, sidechain api.SideChain, network common.Network, block *api.BlockMetadata, data []byte, compression api.Compression) (string, error) {
+	key, err := s.getObjectKey(blockchain, sidechain, network, block, compression)
+	if err != nil {
+		return "", err
+	}
+
+	// #nosec G401
+	h := md5.New()
+	size, err := h.Write(data)
+	if err != nil {
+		return "", xerrors.Errorf("failed to compute checksum: %w", err)
+	}
+
+	checksum := h.Sum(nil)
+
+	object := s.client.Bucket(s.bucket).Object(key)
+	w := object.NewWriter(ctx)
+	finalizer := finalizer.WithCloser(w)
+	defer finalizer.Finalize()
+
+	_, err = w.Write(data)
+	if err != nil {
+		return "", xerrors.Errorf("failed to upload block data: %w", err)
+	}
+	err = finalizer.Close()
+	if err != nil {
+		return "", xerrors.Errorf("failed to upload block data: %w", err)
+	}
+
+	attrs := w.Attrs()
+	if !bytes.Equal(checksum, attrs.MD5) {
+		return "", xerrors.Errorf("uploaded block md5 checksum %x is different from expected %x", attrs.MD5, checksum)
+	}
+
+	// a workaround to use timer
+	s.blobStorageMetrics.blobUploadedSize.Record(time.Duration(size) * time.Millisecond)
+
+	return key, nil
+}
+
+func (s *blobStorageImpl) UploadRaw(ctx context.Context, blockchain common.Blockchain, sidechain api.SideChain, network common.Network, block *api.BlockMetadata, data []byte, compression api.Compression) (string, error) {
+	return s.instrumentUpload.Instrument(ctx, func(ctx context.Context) (string, error) {
+		defer s.logDuration("upload", time.Now())
+
+		// Skip the upload if the block itself is skipped.
+		if block.Skipped {
+			return "", nil
+		}
+
+		return s.uploadRaw(ctx, blockchain, sidechain, network, block, data, compression)
+	})
+}
+
 func (s *blobStorageImpl) Upload(ctx context.Context, block *api.Block, compression api.Compression) (string, error) {
 	return s.instrumentUpload.Instrument(ctx, func(ctx context.Context) (string, error) {
-		var key string
 		defer s.logDuration("upload", time.Now())
 
 		// Skip the upload if the block itself is skipped.
 		if block.Metadata.Skipped {
 			return "", nil
 		}
-
 		data, err := proto.Marshal(block)
 		if err != nil {
 			return "", xerrors.Errorf("failed to marshal block: %w", err)
-		}
-
-		blockchainNetwork := fmt.Sprintf("%s/%s", block.Blockchain, block.Network)
-		tagHeightHash := fmt.Sprintf("%d/%d/%s", block.Metadata.Tag, block.Metadata.Height, block.Metadata.Hash)
-		if s.config.Chain.Sidechain != api.SideChain_SIDECHAIN_NONE {
-			key = fmt.Sprintf(
-				"%s/%s/%s", blockchainNetwork, block.SideChain, tagHeightHash,
-			)
-		} else {
-			key = fmt.Sprintf(
-				"%s/%s", blockchainNetwork, tagHeightHash,
-			)
 		}
 
 		data, err = storage_utils.Compress(data, compression)
 		if err != nil {
 			return "", xerrors.Errorf("failed to compress data with type %v: %w", compression.String(), err)
 		}
-		key, err = storage_utils.GetObjectKey(key, compression)
-		if err != nil {
-			return "", xerrors.Errorf("failed to get object key: %w", err)
-		}
 
-		// #nosec G401
-		h := md5.New()
-		size, err := h.Write(data)
-		if err != nil {
-			return "", xerrors.Errorf("failed to compute checksum: %w", err)
-		}
-
-		checksum := h.Sum(nil)
-
-		object := s.client.Bucket(s.bucket).Object(key)
-		w := object.NewWriter(ctx)
-		finalizer := finalizer.WithCloser(w)
-		defer finalizer.Finalize()
-
-		_, err = w.Write(data)
-		if err != nil {
-			return "", xerrors.Errorf("failed to upload block data: %w", err)
-		}
-		err = finalizer.Close()
-		if err != nil {
-			return "", xerrors.Errorf("failed to upload block data: %w", err)
-		}
-
-		attrs := w.Attrs()
-		if err != nil {
-			return "", xerrors.Errorf("failed to load attributes for uploaded block data: %w", err)
-		}
-		if !bytes.Equal(checksum, attrs.MD5) {
-			return "", xerrors.Errorf("uploaded block md5 checksum %x is different from expected %x", attrs.MD5, checksum)
-		}
-
-		// a workaround to use timer
-		s.blobStorageMetrics.blobUploadedSize.Record(time.Duration(size) * time.Millisecond)
-
-		return key, nil
+		return s.uploadRaw(ctx, block.Blockchain, block.SideChain, block.Network, block.Metadata, data, compression)
 	})
 }
 

--- a/internal/storage/blobstorage/internal/blobstorage.go
+++ b/internal/storage/blobstorage/internal/blobstorage.go
@@ -8,12 +8,14 @@ import (
 
 	"github.com/coinbase/chainstorage/internal/config"
 	"github.com/coinbase/chainstorage/internal/utils/fxparams"
+	"github.com/coinbase/chainstorage/protos/coinbase/c3/common"
 	api "github.com/coinbase/chainstorage/protos/coinbase/chainstorage"
 )
 
 type (
 	BlobStorage interface {
 		Upload(ctx context.Context, block *api.Block, compression api.Compression) (string, error)
+		UploadRaw(ctx context.Context, blockchain common.Blockchain, sidechain api.SideChain, network common.Network, block *api.BlockMetadata, data []byte, compression api.Compression) (string, error)
 		Download(ctx context.Context, metadata *api.BlockMetadata) (*api.Block, error)
 		PreSign(ctx context.Context, objectKey string) (string, error)
 	}

--- a/internal/storage/blobstorage/mocks/mocks.go
+++ b/internal/storage/blobstorage/mocks/mocks.go
@@ -13,6 +13,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	common "github.com/coinbase/chainstorage/protos/coinbase/c3/common"
 	chainstorage "github.com/coinbase/chainstorage/protos/coinbase/chainstorage"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -83,4 +84,19 @@ func (m *MockBlobStorage) Upload(arg0 context.Context, arg1 *chainstorage.Block,
 func (mr *MockBlobStorageMockRecorder) Upload(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upload", reflect.TypeOf((*MockBlobStorage)(nil).Upload), arg0, arg1, arg2)
+}
+
+// UploadRaw mocks base method.
+func (m *MockBlobStorage) UploadRaw(arg0 context.Context, arg1 common.Blockchain, arg2 chainstorage.SideChain, arg3 common.Network, arg4 *chainstorage.BlockMetadata, arg5 []byte, arg6 chainstorage.Compression) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UploadRaw", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UploadRaw indicates an expected call of UploadRaw.
+func (mr *MockBlobStorageMockRecorder) UploadRaw(arg0, arg1, arg2, arg3, arg4, arg5, arg6 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadRaw", reflect.TypeOf((*MockBlobStorage)(nil).UploadRaw), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }

--- a/internal/storage/blobstorage/s3/blob_storage.go
+++ b/internal/storage/blobstorage/s3/blob_storage.go
@@ -27,6 +27,7 @@ import (
 	"github.com/coinbase/chainstorage/internal/utils/fxparams"
 	"github.com/coinbase/chainstorage/internal/utils/instrument"
 	"github.com/coinbase/chainstorage/internal/utils/log"
+	"github.com/coinbase/chainstorage/protos/coinbase/c3/common"
 	api "github.com/coinbase/chainstorage/protos/coinbase/chainstorage"
 )
 
@@ -105,9 +106,72 @@ func newBlobStorageMetrics(scope tally.Scope) *blobStorageMetrics {
 	}
 }
 
+func (s *blobStorageImpl) getObjectKey(blockchain common.Blockchain, sidechain api.SideChain, network common.Network, metadata *api.BlockMetadata, compression api.Compression) (string, error) {
+	var key string
+	var err error
+	blockchainNetwork := fmt.Sprintf("%s/%s", blockchain, network)
+	tagHeightHash := fmt.Sprintf("%d/%d/%s", metadata.Tag, metadata.Height, metadata.Hash)
+	if s.config.Chain.Sidechain != api.SideChain_SIDECHAIN_NONE {
+		key = fmt.Sprintf(
+			"%s/%s/%s", blockchainNetwork, sidechain, tagHeightHash,
+		)
+	} else {
+		key = fmt.Sprintf(
+			"%s/%s", blockchainNetwork, tagHeightHash,
+		)
+	}
+	key, err = storage_utils.GetObjectKey(key, compression)
+	if err != nil {
+		return "", xerrors.Errorf("failed to get object key: %w", err)
+	}
+	return key, nil
+}
+
+func (s *blobStorageImpl) uploadRaw(ctx context.Context, blockchain common.Blockchain, sidechain api.SideChain, network common.Network, block *api.BlockMetadata, data []byte, compression api.Compression) (string, error) {
+	key, err := s.getObjectKey(blockchain, sidechain, network, block, compression)
+	if err != nil {
+		return "", err
+	}
+
+	// #nosec G401
+	h := md5.New()
+	size, err := h.Write(data)
+	if err != nil {
+		return "", xerrors.Errorf("failed to compute checksum: %w", err)
+	}
+
+	checksum := base64.StdEncoding.EncodeToString(h.Sum(nil))
+
+	if _, err := s.uploader.UploadWithContext(ctx, &s3manager.UploadInput{
+		Bucket:     aws.String(s.bucket),
+		Key:        aws.String(key),
+		Body:       bytes.NewReader(data),
+		ContentMD5: aws.String(checksum),
+		ACL:        aws.String(bucketOwnerFullControl),
+	}); err != nil {
+		return "", xerrors.Errorf("failed to upload to s3: %w", err)
+	}
+
+	// a workaround to use timer
+	s.blobStorageMetrics.blobUploadedSize.Record(time.Duration(size) * time.Millisecond)
+
+	return key, nil
+}
+
+func (s *blobStorageImpl) UploadRaw(ctx context.Context, blockchain common.Blockchain, sidechain api.SideChain, network common.Network, block *api.BlockMetadata, data []byte, compression api.Compression) (string, error) {
+	return s.instrumentUpload.Instrument(ctx, func(ctx context.Context) (string, error) {
+		defer s.logDuration("upload", time.Now())
+
+		// Skip the upload if the block itself is skipped.
+		if block.Skipped {
+			return "", nil
+		}
+		return s.uploadRaw(ctx, blockchain, sidechain, network, block, data, compression)
+	})
+}
+
 func (s *blobStorageImpl) Upload(ctx context.Context, block *api.Block, compression api.Compression) (string, error) {
 	return s.instrumentUpload.Instrument(ctx, func(ctx context.Context) (string, error) {
-		var key string
 		defer s.logDuration("upload", time.Now())
 
 		// Skip the upload if the block itself is skipped.
@@ -120,50 +184,11 @@ func (s *blobStorageImpl) Upload(ctx context.Context, block *api.Block, compress
 			return "", xerrors.Errorf("failed to marshal block: %w", err)
 		}
 
-		blockchainNetwork := fmt.Sprintf("%s/%s", block.Blockchain, block.Network)
-		tagHeightHash := fmt.Sprintf("%d/%d/%s", block.Metadata.Tag, block.Metadata.Height, block.Metadata.Hash)
-		if s.config.Chain.Sidechain != api.SideChain_SIDECHAIN_NONE {
-			key = fmt.Sprintf(
-				"%s/%s/%s", blockchainNetwork, block.SideChain, tagHeightHash,
-			)
-		} else {
-			key = fmt.Sprintf(
-				"%s/%s", blockchainNetwork, tagHeightHash,
-			)
-		}
-
 		data, err = storage_utils.Compress(data, compression)
 		if err != nil {
 			return "", xerrors.Errorf("failed to compress data with type %v: %w", compression.String(), err)
 		}
-		key, err = storage_utils.GetObjectKey(key, compression)
-		if err != nil {
-			return "", xerrors.Errorf("failed to get object key: %w", err)
-		}
-
-		// #nosec G401
-		h := md5.New()
-		size, err := h.Write(data)
-		if err != nil {
-			return "", xerrors.Errorf("failed to compute checksum: %w", err)
-		}
-
-		checksum := base64.StdEncoding.EncodeToString(h.Sum(nil))
-
-		if _, err := s.uploader.UploadWithContext(ctx, &s3manager.UploadInput{
-			Bucket:     aws.String(s.bucket),
-			Key:        aws.String(key),
-			Body:       bytes.NewReader(data),
-			ContentMD5: aws.String(checksum),
-			ACL:        aws.String(bucketOwnerFullControl),
-		}); err != nil {
-			return "", xerrors.Errorf("failed to upload to s3: %w", err)
-		}
-
-		// a workaround to use timer
-		s.blobStorageMetrics.blobUploadedSize.Record(time.Duration(size) * time.Millisecond)
-
-		return key, nil
+		return s.uploadRaw(ctx, block.Blockchain, block.SideChain, block.Network, block.Metadata, data, compression)
 	})
 }
 


### PR DESCRIPTION
### What changed? Why?
<!-- Please describe the change and why you made it. -->

Avoid compressing block data by reusing the downloaded bytes.
 
### How did you test the change?
<!-- Please describe how the change was tested. -->

- GitHub Actions
- By running the replicator workflow
