### PR TITLE
feat: replace xerrors with standard Go error handling

### DIFF
--- a/cmd/admin/backfill.go
+++ b/cmd/admin/backfill.go
@@ -8,7 +8,6 @@ import (
 	"github.com/spf13/cobra"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/aws"
 	"github.com/coinbase/chainstorage/internal/blockchain/client"
@@ -69,7 +68,7 @@ var (
 			}
 
 			if startHeight >= endHeight {
-				return xerrors.Errorf("invalid block range: [%v, %v)", startHeight, endHeight)
+				return fmt.Errorf("invalid block range: [%v, %v)", startHeight, endHeight)
 			}
 
 			chainInfo := fmt.Sprintf("%v-%v", commonFlags.blockchain, commonFlags.network)
@@ -89,12 +88,12 @@ var (
 			for height := startHeight; height < endHeight; height++ {
 				block, err := deps.Client.GetBlockByHeight(ctx, tag, height)
 				if err != nil {
-					return xerrors.Errorf("failed to get block: %w", err)
+					return fmt.Errorf("failed to get block: %w", err)
 				}
 
 				objectKey, err := deps.BlobStorage.Upload(ctx, block, compression)
 				if err != nil {
-					return xerrors.Errorf("failed to upload block in blob storage: %w", err)
+					return fmt.Errorf("failed to upload block in blob storage: %w", err)
 				}
 				block.Metadata.ObjectKeyMain = objectKey
 
@@ -109,7 +108,7 @@ var (
 			}
 
 			if err := deps.MetaStorage.PersistBlockMetas(ctx, updateWatermark, blockMetadatas, nil); err != nil {
-				return xerrors.Errorf("failed to persist block in meta storage: %w", err)
+				return fmt.Errorf("failed to persist block in meta storage: %w", err)
 			}
 
 			logger.Info(

--- a/cmd/admin/block.go
+++ b/cmd/admin/block.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/spf13/cobra"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/blockchain/client"
 	"github.com/coinbase/chainstorage/internal/blockchain/endpoints"
@@ -50,11 +50,11 @@ var (
 			tag := deps.Config.GetEffectiveBlockTag(blockFlags.tag)
 			rawBlock, err := deps.Client.GetBlockByHeight(context.Background(), tag, blockFlags.height)
 			if err != nil {
-				return xerrors.Errorf("failed to get block: %w", err)
+				return fmt.Errorf("failed to get block: %w", err)
 			}
 
 			if err := printBlock(deps.Parser, rawBlock, false); err != nil {
-				return xerrors.Errorf("failed to print block: %w", err)
+				return fmt.Errorf("failed to print block: %w", err)
 			}
 			return nil
 		},
@@ -82,7 +82,7 @@ var (
 
 			height, err := deps.Client.GetLatestHeight(context.Background())
 			if err != nil {
-				return xerrors.Errorf("failed to get block: %w", err)
+				return fmt.Errorf("failed to get block: %w", err)
 			}
 
 			logger.Info("latest height", zap.Uint64("height", height))

--- a/cmd/admin/event.go
+++ b/cmd/admin/event.go
@@ -12,7 +12,6 @@ import (
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"go.uber.org/fx"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/aws"
 	"github.com/coinbase/chainstorage/internal/storage"
@@ -51,7 +50,7 @@ var (
 			eventTag := resetWatermarkFlags.eventTag
 			currentMaxEventId, err := deps.EventStorage.GetMaxEventId(context.Background(), eventTag)
 			if err != nil {
-				return xerrors.Errorf("failed to get current max event id: %w", err)
+				return fmt.Errorf("failed to get current max event id: %w", err)
 			}
 			logger.Info(fmt.Sprintf("current currentMaxEventId is %d", currentMaxEventId))
 
@@ -72,7 +71,7 @@ var (
 
 			response, err := bufio.NewReader(os.Stdin).ReadString('\n')
 			if err != nil {
-				return xerrors.Errorf("failed to read from console: %w", err)
+				return fmt.Errorf("failed to read from console: %w", err)
 			}
 
 			if strings.ToLower(strings.TrimSpace(response)) != "y" {
@@ -84,7 +83,7 @@ var (
 					zap.Int64("maxEventId", resetWatermarkFlags.eventId),
 					zap.Uint32("eventTag", eventTag),
 				)
-				return xerrors.Errorf("failed to set max event id with eventTag=%v: %w", eventTag, err)
+				return fmt.Errorf("failed to set max event id with eventTag=%v: %w", eventTag, err)
 			} else {
 				logger.Info("successfully set max event id",
 					zap.Int64("maxEventId", resetWatermarkFlags.eventId),

--- a/cmd/admin/workflow.go
+++ b/cmd/admin/workflow.go
@@ -10,7 +10,6 @@ import (
 	"go.temporal.io/sdk/client"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/aws"
 	blockchainModule "github.com/coinbase/chainstorage/internal/blockchain"
@@ -92,24 +91,24 @@ func init() {
 func startWorkflow() error {
 	workflowIdentity := workflow.GetWorkflowIdentify(workflowFlags.workflow)
 	if workflowIdentity == workflow.UnknownIdentity {
-		return xerrors.Errorf("invalid workflow: %v", workflowFlags.workflow)
+		return fmt.Errorf("invalid workflow: %v", workflowFlags.workflow)
 	}
 
 	app, executors, err := initApp()
 	if err != nil {
-		return xerrors.Errorf("failed to init app: %w", err)
+		return fmt.Errorf("failed to init app: %w", err)
 	}
 	defer app.Close()
 
 	ctx := context.Background()
 	workflowIdentityString, err := workflowIdentity.String()
 	if err != nil {
-		return xerrors.Errorf("error parsing workflowIdentity: %w", err)
+		return fmt.Errorf("error parsing workflowIdentity: %w", err)
 	}
 
 	req, err := workflowIdentity.UnmarshalJsonStringToRequest(workflowFlags.input)
 	if err != nil {
-		return xerrors.Errorf("error converting input flag to request: %w", err)
+		return fmt.Errorf("error converting input flag to request: %w", err)
 	}
 
 	if !confirmWorkflowOperation("start", workflowIdentityString, req) {
@@ -121,60 +120,60 @@ func startWorkflow() error {
 	case workflow.BackfillerIdentity:
 		request, ok := req.(workflow.BackfillerRequest)
 		if !ok {
-			return xerrors.Errorf("error converting to request type")
+			return fmt.Errorf("error converting to request type")
 		}
 		run, err = executors.Backfiller.Execute(ctx, &request)
 	case workflow.MonitorIdentity:
 		request, ok := req.(workflow.MonitorRequest)
 		if !ok {
-			return xerrors.Errorf("error converting to request type")
+			return fmt.Errorf("error converting to request type")
 		}
 		run, err = executors.Monitor.Execute(ctx, &request)
 	case workflow.PollerIdentity:
 		request, ok := req.(workflow.PollerRequest)
 		if !ok {
-			return xerrors.Errorf("error converting to request type")
+			return fmt.Errorf("error converting to request type")
 		}
 		run, err = executors.Poller.Execute(ctx, &request)
 	case workflow.StreamerIdentity:
 		request, ok := req.(workflow.StreamerRequest)
 		if !ok {
-			return xerrors.Errorf("error converting to request type")
+			return fmt.Errorf("error converting to request type")
 		}
 		run, err = executors.Streamer.Execute(ctx, &request)
 	case workflow.BenchmarkerIdentity:
 		request, ok := req.(workflow.BenchmarkerRequest)
 		if !ok {
-			return xerrors.Errorf("error converting to request type")
+			return fmt.Errorf("error converting to request type")
 		}
 		run, err = executors.Benchmarker.Execute(ctx, &request)
 	case workflow.CrossValidatorIdentity:
 		request, ok := req.(workflow.CrossValidatorRequest)
 		if !ok {
-			return xerrors.Errorf("error converting to request type")
+			return fmt.Errorf("error converting to request type")
 		}
 		run, err = executors.CrossValidator.Execute(ctx, &request)
 	case workflow.EventBackfillerIdentity:
 		request, ok := req.(workflow.EventBackfillerRequest)
 		if !ok {
-			return xerrors.Errorf("error converting to request type")
+			return fmt.Errorf("error converting to request type")
 		}
 		run, err = executors.EventBackfiller.Execute(ctx, &request)
 	case workflow.ReplicatorIdentity:
 		request, ok := req.(workflow.ReplicatorRequest)
 		if !ok {
-			return xerrors.Errorf("error converting to request type")
+			return fmt.Errorf("error converting to request type")
 		}
 		run, err = executors.Replicator.Execute(ctx, &request)
 	default:
-		return xerrors.Errorf("unsupported workflow identity: %v", workflowIdentity)
+		return fmt.Errorf("unsupported workflow identity: %v", workflowIdentity)
 	}
 
 	if err != nil {
 		logger.Error("failed to start workflow",
 			zap.String("workflowIdentity", workflowIdentityString),
 		)
-		return xerrors.Errorf("failed to start workflow: %w", err)
+		return fmt.Errorf("failed to start workflow: %w", err)
 	}
 
 	workflowURL := getWorkflowURL(app, run)
@@ -192,12 +191,12 @@ func stopWorkflow() error {
 	var err error
 	workflowIdentity := workflow.GetWorkflowIdentify(workflowFlags.workflow)
 	if workflowIdentity == workflow.UnknownIdentity {
-		return xerrors.Errorf("invalid workflow: %v", workflowFlags.workflow)
+		return fmt.Errorf("invalid workflow: %v", workflowFlags.workflow)
 	}
 
 	app, executors, err := initApp()
 	if err != nil {
-		return xerrors.Errorf("failed to init app: %w", err)
+		return fmt.Errorf("failed to init app: %w", err)
 	}
 	defer app.Close()
 
@@ -206,7 +205,7 @@ func stopWorkflow() error {
 	} else {
 		workflowIdentityString, err = workflowIdentity.String()
 		if err != nil {
-			return xerrors.Errorf("error parsing workflowIdentity: %w", err)
+			return fmt.Errorf("error parsing workflowIdentity: %w", err)
 		}
 	}
 	if !confirmWorkflowOperation("stop", workflowIdentityString, nil) {
@@ -237,11 +236,11 @@ func stopWorkflow() error {
 	case workflow.ReplicatorIdentity:
 		err = executors.Replicator.StopWorkflow(ctx, workflowIdentityString, reason)
 	default:
-		return xerrors.Errorf("unsupported workflow identity: %v", workflowIdentity)
+		return fmt.Errorf("unsupported workflow identity: %v", workflowIdentity)
 	}
 
 	if err != nil {
-		return xerrors.Errorf("failed to stop workflow for workflowID=%s: %w", workflowIdentityString, err)
+		return fmt.Errorf("failed to stop workflow for workflowID=%s: %w", workflowIdentityString, err)
 	}
 
 	logger.Info("stopped workflow",

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/btcsuite/btcd/btcutil v1.1.5
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/cenkalti/backoff/v4 v4.2.1
+	github.com/cockroachdb/errors v1.9.1
 	github.com/coinbase/rosetta-sdk-go v0.8.3
 	github.com/coinbase/rosetta-sdk-go/types v1.0.0
 	github.com/ethereum/go-ethereum v1.13.11
@@ -47,7 +48,6 @@ require (
 	golang.org/x/sync v0.6.0
 	golang.org/x/text v0.14.0
 	golang.org/x/time v0.5.0
-	golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028
 	google.golang.org/api v0.158.0
 	google.golang.org/grpc v1.61.0
 	google.golang.org/protobuf v1.32.0
@@ -82,7 +82,6 @@ require (
 	github.com/btcsuite/btcd/btcec/v2 v2.3.2 // indirect
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
-	github.com/cockroachdb/errors v1.9.1 // indirect
 	github.com/cockroachdb/logtags v0.0.0-20230118201751-21c54148d20b // indirect
 	github.com/cockroachdb/pebble v0.0.0-20230928194634-aa077af62593 // indirect
 	github.com/cockroachdb/redact v1.1.3 // indirect
@@ -196,6 +195,7 @@ require (
 	golang.org/x/sys v0.16.0 // indirect
 	golang.org/x/term v0.16.0 // indirect
 	golang.org/x/tools v0.17.0 // indirect
+	golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/genproto v0.0.0-20240125205218-1f4bbc51befe // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240125205218-1f4bbc51befe // indirect

--- a/internal/aws/session.go
+++ b/internal/aws/session.go
@@ -1,10 +1,11 @@
 package aws
 
 import (
+	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"go.uber.org/fx"
-	"golang.org/x/xerrors"
 	awstrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/aws/aws-sdk-go/aws"
 
 	"github.com/coinbase/chainstorage/internal/utils/fxparams"
@@ -21,7 +22,7 @@ type (
 func NewSession(params SessionParams) (*session.Session, error) {
 	awsSession, err := session.NewSession(params.AWSConfig)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to create AWS session: %w", err)
+		return nil, fmt.Errorf("failed to create AWS session: %w", err)
 	}
 
 	// wrap aws session for tracing requests and responses

--- a/internal/blockchain/bootstrap/bootstrap_genesis.go
+++ b/internal/blockchain/bootstrap/bootstrap_genesis.go
@@ -1,10 +1,9 @@
 package bootstrap
 
 import (
+	"errors"
 	"fmt"
 	"strings"
-
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/utils/fixtures"
 	"github.com/coinbase/chainstorage/protos/coinbase/c3/common"
@@ -29,7 +28,7 @@ type Currency struct {
 // for a particular genesis file.
 func GenerateGenesisAllocations(network common.Network) ([]*GenesisAllocation, error) {
 	if network.GetName() == "" {
-		return nil, xerrors.New("network name is empty")
+		return nil, errors.New("network name is empty")
 	}
 	chainInfo := strings.Split(network.GetName(), "-")
 	filePath := fmt.Sprintf("genesis_files/%s/%s.json", chainInfo[0], chainInfo[1])

--- a/internal/blockchain/client/aptos/aptos_test.go
+++ b/internal/blockchain/client/aptos/aptos_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/fx"
 	"go.uber.org/mock/gomock"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/blockchain/client/internal"
 	"github.com/coinbase/chainstorage/internal/blockchain/jsonrpc"
@@ -142,7 +141,7 @@ func (s *aptosClientTestSuite) TestBatchGetBlockMetadata_Failure() {
 		Code:     http.StatusInternalServerError,
 		Response: string(response),
 	}
-	callErr := xerrors.Errorf("received http error: %w", &expectedHTTPErr)
+	callErr := fmt.Errorf("received http error: %w", &expectedHTTPErr)
 
 	s.restClient.EXPECT().Call(gomock.Any(), expectedMethod1, gomock.Any()).Return(metaResponse1, nil)
 	// Make the second request failed
@@ -199,7 +198,7 @@ func (s *aptosClientTestSuite) TestGetBlockByHeight_AptosError() {
 		Code:     http.StatusInternalServerError,
 		Response: string(response),
 	}
-	callErr := xerrors.Errorf("received http error: %w", &expectedHTTPErr)
+	callErr := fmt.Errorf("received http error: %w", &expectedHTTPErr)
 
 	expectedMethod := &restapi.RequestMethod{
 		Name:       "GetBlockByHeight",
@@ -231,7 +230,7 @@ func (s *aptosClientTestSuite) TestGetBlockByHeight_NotFound() {
 		VmErrorCode: 0,
 	}
 	response, _ := json.Marshal(&expectedErrAptos)
-	callErr := xerrors.Errorf("received http error: %w", &restapi.HTTPError{
+	callErr := fmt.Errorf("received http error: %w", &restapi.HTTPError{
 		Code:     http.StatusInternalServerError,
 		Response: string(response),
 	})
@@ -296,7 +295,7 @@ func (s *aptosClientTestSuite) TestGetBlockByHash_AptosError() {
 		Code:     http.StatusInternalServerError,
 		Response: string(response),
 	}
-	callErr := xerrors.Errorf("received http error: %w", &expectedHTTPErr)
+	callErr := fmt.Errorf("received http error: %w", &expectedHTTPErr)
 
 	expectedMethod := &restapi.RequestMethod{
 		Name:       "GetBlockByHeight",
@@ -387,7 +386,7 @@ func (s *aptosClientTestSuite) TestGetLatestBlock_AptosError() {
 		Code:     http.StatusInternalServerError,
 		Response: string(response),
 	}
-	callErr := xerrors.Errorf("received http error: %w", &expectedHTTPErr)
+	callErr := fmt.Errorf("received http error: %w", &expectedHTTPErr)
 
 	expectedMethod := &restapi.RequestMethod{
 		Name:       "GetLedgerInfo",

--- a/internal/blockchain/client/bitcoin/bitcoin_test.go
+++ b/internal/blockchain/client/bitcoin/bitcoin_test.go
@@ -3,12 +3,13 @@ package bitcoin
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/fx"
 	"go.uber.org/mock/gomock"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/blockchain/client/internal"
 	"github.com/coinbase/chainstorage/internal/blockchain/jsonrpc"
@@ -316,7 +317,7 @@ func (s *bitcoinClientTestSuite) TestBitcoinClient_GetBlockByHeight_BlockOutOfRa
 
 	_, err := s.client.GetBlockByHeight(context.Background(), btcTag, btcFixtureBlockHeight)
 	s.Error(err)
-	s.True(xerrors.Is(err, internal.ErrBlockNotFound), err.Error())
+	s.True(errors.Is(err, internal.ErrBlockNotFound), err.Error())
 }
 
 func (s *bitcoinClientTestSuite) TestBitcoinClient_GetBlockByHeight_BlockNotFound() {
@@ -343,7 +344,7 @@ func (s *bitcoinClientTestSuite) TestBitcoinClient_GetBlockByHeight_BlockNotFoun
 	).Return(nil, getBlockByHashResponse.Error)
 
 	block, err := s.client.GetBlockByHeight(context.Background(), btcTag, btcFixtureBlockHeight)
-	s.True(xerrors.Is(err, internal.ErrBlockNotFound))
+	s.True(errors.Is(err, internal.ErrBlockNotFound))
 	s.Nil(block)
 }
 
@@ -438,7 +439,7 @@ func (s *bitcoinClientTestSuite) TestBitcoinClient_GetBlockByHash_BlockNotFound(
 	).Return(nil, blockResponse.Error)
 
 	block, err := s.client.GetBlockByHash(context.Background(), btcTag, btcFixtureBlockHeight, btcFixtureBlockHash)
-	s.True(xerrors.Is(err, internal.ErrBlockNotFound))
+	s.True(errors.Is(err, internal.ErrBlockNotFound))
 	s.Nil(block)
 }
 
@@ -551,7 +552,7 @@ func (s *bitcoinClientTestSuite) TestBitcoinClient_GetBlockByHash_GetInputTransa
 	}
 	s.rpcClient.EXPECT().BatchCall(
 		gomock.Any(), bitcoinGetRawTransactionMethod, expectedParams,
-	).Return(nil, xerrors.Errorf("error making http requests"))
+	).Return(nil, fmt.Errorf("error making http requests"))
 
 	block, err := s.client.GetBlockByHash(context.Background(), btcTag, btcFixtureBlockHeight, btcFixtureBlockHash)
 	s.Error(err)
@@ -596,7 +597,7 @@ func (s *bitcoinClientTestSuite) TestBitcoinClient_GetBlockByHash_GetRawTransact
 	}
 	s.rpcClient.EXPECT().BatchCall(
 		gomock.Any(), bitcoinGetRawTransactionMethod, expectedParams,
-	).Return(getRawTransactionResponse, xerrors.Errorf("error making http requests"))
+	).Return(getRawTransactionResponse, fmt.Errorf("error making http requests"))
 
 	block, err := s.client.GetBlockByHash(context.Background(), btcTag, btcFixtureBlockHeight, btcFixtureBlockHash)
 	s.Error(err)
@@ -700,7 +701,7 @@ func (s *bitcoinClientTestSuite) TestBitcoinClient_GetLatestHeight_ResponseError
 func (s *bitcoinClientTestSuite) TestBitcoinClient_GetLatestHeight_CallError() {
 	s.rpcClient.EXPECT().Call(
 		gomock.Any(), bitcoinGetBlockCountMethod, jsonrpc.Params{},
-	).Return(nil, xerrors.Errorf("error making http request"))
+	).Return(nil, fmt.Errorf("error making http request"))
 
 	height, err := s.client.GetLatestHeight(context.Background())
 	s.Error(err)
@@ -784,7 +785,7 @@ func (s *bitcoinClientTestSuite) TestBitcoinClient_BatchGetBlockMetadataByRange_
 
 	s.rpcClient.EXPECT().BatchCall(
 		gomock.Any(), bitcoinGetBlockHashMethod, getBlockHashesParams,
-	).Return(nil, xerrors.Errorf("error making http request"))
+	).Return(nil, fmt.Errorf("error making http request"))
 
 	metadata, err := s.client.BatchGetBlockMetadata(context.Background(), btcTag, 101, 104)
 	s.Error(err)
@@ -829,7 +830,7 @@ func (s *bitcoinClientTestSuite) TestBitcoinClient_BatchGetBlockMetadataByRange_
 
 	s.rpcClient.EXPECT().BatchCall(
 		gomock.Any(), bitcoinGetBlockByHashMethod, getBlocksParams,
-	).Return(nil, xerrors.Errorf("error getting blocks"))
+	).Return(nil, fmt.Errorf("error getting blocks"))
 
 	metadata, err := s.client.BatchGetBlockMetadata(context.Background(), btcTag, 101, 104)
 	s.Error(err)

--- a/internal/blockchain/client/ethereum/arbitrum_test.go
+++ b/internal/blockchain/client/ethereum/arbitrum_test.go
@@ -3,12 +3,12 @@ package ethereum
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/fx"
 	"go.uber.org/mock/gomock"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/blockchain/client/internal"
 	"github.com/coinbase/chainstorage/internal/blockchain/parser"
@@ -114,7 +114,7 @@ func (s *arbitrumClientTestSuite) TestArbitrumTest_GetBlockByHeight() {
 				return transactionResponse, nil
 			}
 
-			return nil, xerrors.Errorf("unknown method: %v", method)
+			return nil, fmt.Errorf("unknown method: %v", method)
 		})
 
 	receiptResponse := []*jsonrpc.Response{
@@ -163,7 +163,7 @@ func (s *arbitrumClientTestSuite) TestArbitrumTest_GetBlockByHash_WithoutBestEff
 				return transactionResponse, nil
 			}
 
-			return nil, xerrors.Errorf("unknown method: %v", method)
+			return nil, fmt.Errorf("unknown method: %v", method)
 		})
 
 	receiptResponse := []*jsonrpc.Response{
@@ -210,7 +210,7 @@ func (s *arbitrumClientTestSuite) TestArbitrumTest_GetBlockByHeight_ServerError(
 				return &jsonrpc.Response{}, rpcErr
 			}
 
-			return nil, xerrors.Errorf("unknown method: %v", method)
+			return nil, fmt.Errorf("unknown method: %v", method)
 		})
 
 	receiptResponse := []*jsonrpc.Response{
@@ -256,7 +256,7 @@ func (s *arbitrumClientTestSuite) TestArbitrumTest_SkipTxnForSpecificBlocks() {
 				return transactionResponse, nil
 			}
 
-			return nil, xerrors.Errorf("unknown method: %v", method)
+			return nil, fmt.Errorf("unknown method: %v", method)
 		})
 
 	receiptResponse := []*jsonrpc.Response{
@@ -331,7 +331,7 @@ func (s *arbitrumClientTestSuite) TestArbitrum_GetTracesByDebugEndpoint_Success(
 				return transactionResponse, nil
 			}
 
-			return nil, xerrors.Errorf("unknown method: %v", method)
+			return nil, fmt.Errorf("unknown method: %v", method)
 		})
 
 	receiptResponse := []*jsonrpc.Response{

--- a/internal/blockchain/client/ethereum/avacchain_test.go
+++ b/internal/blockchain/client/ethereum/avacchain_test.go
@@ -3,12 +3,12 @@ package ethereum
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/fx"
 	"go.uber.org/mock/gomock"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/blockchain/client/internal"
 	"github.com/coinbase/chainstorage/internal/blockchain/jsonrpc"
@@ -107,10 +107,10 @@ func (s *avacchainClientTestSuite) TestAvacchainTest_GetBlockByHeight() {
 					}, nil
 				}
 
-				return nil, xerrors.Errorf("unknown tracer: %v", tracer)
+				return nil, fmt.Errorf("unknown tracer: %v", tracer)
 			}
 
-			return nil, xerrors.Errorf("unknown method: %v", method)
+			return nil, fmt.Errorf("unknown method: %v", method)
 		})
 
 	receiptResponse := []*jsonrpc.Response{

--- a/internal/blockchain/client/ethereum/base_test.go
+++ b/internal/blockchain/client/ethereum/base_test.go
@@ -2,12 +2,12 @@ package ethereum
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/fx"
 	"go.uber.org/mock/gomock"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/blockchain/client/internal"
 	"github.com/coinbase/chainstorage/internal/blockchain/jsonrpc"
@@ -120,10 +120,10 @@ func (s *baseClientTestSuite) TestBaseTest_GetBlockByHeight_WithBestEffort() {
 					return transactionResponse, nil
 				}
 
-				return nil, xerrors.Errorf("unknown tracer: %v", tracer)
+				return nil, fmt.Errorf("unknown tracer: %v", tracer)
 			}
 
-			return nil, xerrors.Errorf("unknown method: %v", method)
+			return nil, fmt.Errorf("unknown method: %v", method)
 		})
 
 	receiptResponse := []*jsonrpc.Response{
@@ -183,10 +183,10 @@ func (s *baseClientTestSuite) TestBaseTest_GetBlockByHeight_WithoutBestEffort() 
 					return transactionResponse, nil
 				}
 
-				return nil, xerrors.Errorf("unknown tracer: %v", tracer)
+				return nil, fmt.Errorf("unknown tracer: %v", tracer)
 			}
 
-			return nil, xerrors.Errorf("unknown method: %v", method)
+			return nil, fmt.Errorf("unknown method: %v", method)
 		})
 
 	receiptResponse := []*jsonrpc.Response{

--- a/internal/blockchain/client/ethereum/beacon/client_test.go
+++ b/internal/blockchain/client/ethereum/beacon/client_test.go
@@ -2,6 +2,7 @@ package beacon
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"net/http"
@@ -11,7 +12,6 @@ import (
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/fx"
 	"go.uber.org/mock/gomock"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/blockchain/client/internal"
 	"github.com/coinbase/chainstorage/internal/blockchain/parser"
@@ -112,7 +112,7 @@ func (s *clientTestSuite) TestEthereumBeacon_GetLatestBlock() {
 func (s *clientTestSuite) TestEthereumBeacon_GetLatestBlock_Failure() {
 	require := testutil.Require(s.T())
 
-	fakeErr := xerrors.Errorf("received http error: %w", &restapi.HTTPError{
+	fakeErr := fmt.Errorf("received http error: %w", &restapi.HTTPError{
 		Code:     http.StatusInternalServerError,
 		Response: "fake http error",
 	})
@@ -129,7 +129,7 @@ func (s *clientTestSuite) TestEthereumBeacon_GetLatestBlock_Failure() {
 	require.Error(err)
 
 	var errHTTP *restapi.HTTPError
-	require.True(xerrors.As(err, &errHTTP))
+	require.True(errors.As(err, &errHTTP))
 	require.Equal(http.StatusInternalServerError, errHTTP.Code)
 }
 
@@ -184,7 +184,7 @@ func (s *clientTestSuite) TestEthereumBeacon_BatchGetBlockMetadata() {
 func (s *clientTestSuite) TestEthereumBeacon_BatchGetBlockMetadata_SkippedBlock() {
 	require := testutil.Require(s.T())
 
-	fakeErr := xerrors.Errorf("fake http error: %w", &restapi.HTTPError{
+	fakeErr := fmt.Errorf("fake http error: %w", &restapi.HTTPError{
 		Code:     http.StatusNotFound,
 		Response: "fake http error",
 	})
@@ -293,7 +293,7 @@ func (s *clientTestSuite) TestEthereumBeacon_GetBlockByHeight() {
 func (s *clientTestSuite) TestEthereumBeacon_GetBlockByHeight_SkippedBlock() {
 	require := testutil.Require(s.T())
 
-	fakeErr := xerrors.Errorf("fake http error: %w", &restapi.HTTPError{
+	fakeErr := fmt.Errorf("fake http error: %w", &restapi.HTTPError{
 		Code:     http.StatusNotFound,
 		Response: "fake http error",
 	})
@@ -330,7 +330,7 @@ func (s *clientTestSuite) TestEthereumBeacon_GetBlockByHeight_SkippedBlock() {
 func (s *clientTestSuite) TestEthereumBeacon_GetBlockByHeight_BlockNotFound() {
 	require := testutil.Require(s.T())
 
-	fakeErr := xerrors.Errorf("fake http error: %w", &restapi.HTTPError{
+	fakeErr := fmt.Errorf("fake http error: %w", &restapi.HTTPError{
 		Code:     http.StatusNotFound,
 		Response: "fake http error",
 	})
@@ -362,7 +362,7 @@ func (s *clientTestSuite) TestEthereumBeacon_GetBlockByHeight_BlockNotFound() {
 func (s *clientTestSuite) TestEthereumBeacon_GetBlockByHeight_BlobsNotFound() {
 	require := testutil.Require(s.T())
 
-	fakeErr := xerrors.Errorf("fake http error: %w", &restapi.HTTPError{
+	fakeErr := fmt.Errorf("fake http error: %w", &restapi.HTTPError{
 		Code:     http.StatusNotFound,
 		Response: "fake http error",
 	})
@@ -518,7 +518,7 @@ func (s *clientTestSuite) TestEthereumBeacon_GetBlockByHash_SkippedBlock() {
 func (s *clientTestSuite) TestEthereumBeacon_GetBlockByHash_HeaderNotFound() {
 	require := testutil.Require(s.T())
 
-	fakeErr := xerrors.Errorf("fake http error: %w", &restapi.HTTPError{
+	fakeErr := fmt.Errorf("fake http error: %w", &restapi.HTTPError{
 		Code:     http.StatusNotFound,
 		Response: "fake http error",
 	})
@@ -575,7 +575,7 @@ func (s *clientTestSuite) TestEthereumBeacon_GetBlockByHash_MismatchBlockHash() 
 func (s *clientTestSuite) TestEthereumBeacon_GetBlockByHash_BlockNotFound() {
 	require := testutil.Require(s.T())
 
-	fakeErr := xerrors.Errorf("fake http error: %w", &restapi.HTTPError{
+	fakeErr := fmt.Errorf("fake http error: %w", &restapi.HTTPError{
 		Code:     http.StatusNotFound,
 		Response: "fake http error",
 	})
@@ -606,7 +606,7 @@ func (s *clientTestSuite) TestEthereumBeacon_GetBlockByHash_BlockNotFound() {
 func (s *clientTestSuite) TestEthereumBeacon_GetBlockByHash_BlobsNotFound() {
 	require := testutil.Require(s.T())
 
-	fakeErr := xerrors.Errorf("fake http error: %w", &restapi.HTTPError{
+	fakeErr := fmt.Errorf("fake http error: %w", &restapi.HTTPError{
 		Code:     http.StatusNotFound,
 		Response: "fake http error",
 	})
@@ -646,7 +646,7 @@ func (s *clientTestSuite) TestEthereumBeacon_GetBlockByHash_BlobsNotFound() {
 func (s *clientTestSuite) TestEthereumBeacon_GetBlockByHash_GetBlockRetry() {
 	require := testutil.Require(s.T())
 
-	fakeErr := xerrors.Errorf("fake http error: %w", &restapi.HTTPError{
+	fakeErr := fmt.Errorf("fake http error: %w", &restapi.HTTPError{
 		Code:     http.StatusNotFound,
 		Response: "fake http error",
 	})
@@ -712,7 +712,7 @@ func (s *clientTestSuite) TestEthereumBeacon_GetBlockByHash_GetBlockRetry() {
 func (s *clientTestSuite) TestEthereumBeacon_GetBlockByHash_GetBlobsRetry() {
 	require := testutil.Require(s.T())
 
-	fakeErr := xerrors.Errorf("fake http error: %w", &restapi.HTTPError{
+	fakeErr := fmt.Errorf("fake http error: %w", &restapi.HTTPError{
 		Code:     http.StatusNotFound,
 		Response: "fake http error",
 	})
@@ -864,7 +864,7 @@ func (s *clientTestSuite) TestEthereumBeacon_GetBlockTimestamp() {
 }
 
 func (s *clientTestSuite) TestEthereumBeacon_GetBlockTimestamp_Failure() {
-	fakeErr := xerrors.Errorf("fake http error: %w", &restapi.HTTPError{
+	fakeErr := fmt.Errorf("fake http error: %w", &restapi.HTTPError{
 		Code:     http.StatusNotFound,
 		Response: "fake http error",
 	})

--- a/internal/blockchain/client/ethereum/ethereum_test.go
+++ b/internal/blockchain/client/ethereum/ethereum_test.go
@@ -3,6 +3,7 @@ package ethereum
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/big"
 	"strconv"
@@ -14,7 +15,6 @@ import (
 
 	"go.uber.org/fx"
 	"go.uber.org/mock/gomock"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/blockchain/client/internal"
 	"github.com/coinbase/chainstorage/internal/blockchain/jsonrpc"
@@ -404,7 +404,7 @@ func TestEthereumClient_GetBlockByHeightWithEmptyHash(t *testing.T) {
 	require.NotNil(client)
 	_, err := client.GetBlockByHeight(context.Background(), tag, 11322000)
 	require.Error(err)
-	require.True(xerrors.Is(err, internal.ErrBlockNotFound))
+	require.True(errors.Is(err, internal.ErrBlockNotFound))
 }
 
 func TestEthereumClient_GetBlockByHash_UnfinalizedDataError(t *testing.T) {
@@ -438,7 +438,7 @@ func TestEthereumClient_GetBlockByHash_UnfinalizedDataError(t *testing.T) {
 	require.NotNil(client)
 	_, err := client.GetBlockByHash(context.Background(), tag, ethereumHeight, ethereumHash)
 	require.Error(err)
-	require.True(xerrors.Is(err, internal.ErrBlockNotFound))
+	require.True(errors.Is(err, internal.ErrBlockNotFound))
 }
 
 func TestEthereumClient_GetBlockByHeightWithBlockZero(t *testing.T) {
@@ -509,10 +509,10 @@ func TestEthereumClient_GetBlockByHeightWithBestEffort(t *testing.T) {
 					}, nil
 				}
 
-				return nil, xerrors.Errorf("unknown tracer: %v", tracer)
+				return nil, fmt.Errorf("unknown tracer: %v", tracer)
 			}
 
-			return nil, xerrors.Errorf("unknown method: %v", method)
+			return nil, fmt.Errorf("unknown method: %v", method)
 		})
 
 	receiptResponse := []*jsonrpc.Response{
@@ -1021,7 +1021,7 @@ func TestEthereumClient_GetBlockByHashExecutionTimeoutError(t *testing.T) {
 				}, nil
 
 			default:
-				return nil, xerrors.Errorf("unknown method: %v", method)
+				return nil, fmt.Errorf("unknown method: %v", method)
 			}
 		})
 
@@ -1156,7 +1156,7 @@ func TestEthereumClient_RetryOrphanedTransactionReceipts_RetryLimitExceeded(t *t
 
 	_, err := client.GetBlockByHeight(context.Background(), tag, 0xacc290)
 	require.Error(err)
-	require.True(xerrors.Is(err, internal.ErrBlockNotFound))
+	require.True(errors.Is(err, internal.ErrBlockNotFound))
 }
 
 func TestCanReprocess(t *testing.T) {

--- a/internal/blockchain/client/ethereum/fantom_test.go
+++ b/internal/blockchain/client/ethereum/fantom_test.go
@@ -3,12 +3,12 @@ package ethereum
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/fx"
 	"go.uber.org/mock/gomock"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/blockchain/client/internal"
 	"github.com/coinbase/chainstorage/internal/blockchain/jsonrpc"
@@ -114,7 +114,7 @@ func (s *fantomClientTestSuite) TestFantomTest_GetBlockByHeight() {
 				return transactionResponse, nil
 			}
 
-			return nil, xerrors.Errorf("unknown method: %v", method)
+			return nil, fmt.Errorf("unknown method: %v", method)
 		})
 
 	receiptResponse := []*jsonrpc.Response{
@@ -163,7 +163,7 @@ func (s *fantomClientTestSuite) TestFantomTest_GetBlockByHash_WithoutBestEffort(
 				return transactionResponse, nil
 			}
 
-			return nil, xerrors.Errorf("unknown method: %v", method)
+			return nil, fmt.Errorf("unknown method: %v", method)
 		})
 
 	receiptResponse := []*jsonrpc.Response{
@@ -210,7 +210,7 @@ func (s *fantomClientTestSuite) TestFantomTest_GetBlockByHeight_ServerError() {
 				return &jsonrpc.Response{}, rpcErr
 			}
 
-			return nil, xerrors.Errorf("unknown method: %v", method)
+			return nil, fmt.Errorf("unknown method: %v", method)
 		})
 
 	receiptResponse := []*jsonrpc.Response{

--- a/internal/blockchain/client/ethereum/optimism_test.go
+++ b/internal/blockchain/client/ethereum/optimism_test.go
@@ -3,12 +3,12 @@ package ethereum
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/fx"
 	"go.uber.org/mock/gomock"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/blockchain/client/internal"
 	"github.com/coinbase/chainstorage/internal/blockchain/jsonrpc"
@@ -158,10 +158,10 @@ func (s *optimismClientTestSuite) TestOptimismTest_GetBlockByHeight_WithBestEffo
 					}, nil
 				}
 
-				return nil, xerrors.Errorf("unknown tracer: %v", tracer)
+				return nil, fmt.Errorf("unknown tracer: %v", tracer)
 			}
 
-			return nil, xerrors.Errorf("unknown method: %v", method)
+			return nil, fmt.Errorf("unknown method: %v", method)
 		})
 
 	receiptResponse := []*jsonrpc.Response{
@@ -210,10 +210,10 @@ func (s *optimismClientTestSuite) TestOptimismTest_GetBlockByHeight_WithoutBestE
 					}, nil
 				}
 
-				return nil, xerrors.Errorf("unknown tracer: %v", tracer)
+				return nil, fmt.Errorf("unknown tracer: %v", tracer)
 			}
 
-			return nil, xerrors.Errorf("unknown method: %v", method)
+			return nil, fmt.Errorf("unknown method: %v", method)
 		})
 
 	receiptResponse := []*jsonrpc.Response{
@@ -261,10 +261,10 @@ func (s *optimismClientTestSuite) TestOptimismTest_FakeBlockTrace() {
 					}, nil
 				}
 
-				return nil, xerrors.Errorf("unknown tracer: %v", tracer)
+				return nil, fmt.Errorf("unknown tracer: %v", tracer)
 			}
 
-			return nil, xerrors.Errorf("unknown method: %v", method)
+			return nil, fmt.Errorf("unknown method: %v", method)
 		})
 
 	receiptResponse := []*jsonrpc.Response{
@@ -320,10 +320,10 @@ func (s *optimismClientTestSuite) TestOptimismTest_FakeTransactionTrace() {
 					return nil, &jsonrpc.RPCError{Code: -32000, Message: optimismWhitelistError}
 				}
 
-				return nil, xerrors.Errorf("unknown tracer: %v", tracer)
+				return nil, fmt.Errorf("unknown tracer: %v", tracer)
 			}
 
-			return nil, xerrors.Errorf("unknown method: %v", method)
+			return nil, fmt.Errorf("unknown method: %v", method)
 		})
 
 	receiptResponse := []*jsonrpc.Response{

--- a/internal/blockchain/client/ethereum/polygon_test.go
+++ b/internal/blockchain/client/ethereum/polygon_test.go
@@ -3,12 +3,13 @@ package ethereum
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/fx"
 	"go.uber.org/mock/gomock"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/blockchain/client/internal"
 	"github.com/coinbase/chainstorage/internal/blockchain/jsonrpc"
@@ -125,7 +126,7 @@ func (s *polygonClientTestSuite) TestPolygonTest_GetBlockByHeight() {
 					}, nil
 				}
 
-				return nil, xerrors.Errorf("unknown tracer: %v", tracer)
+				return nil, fmt.Errorf("unknown tracer: %v", tracer)
 			}
 
 			if method == ethBorGetAuthorMethod {
@@ -139,7 +140,7 @@ func (s *polygonClientTestSuite) TestPolygonTest_GetBlockByHeight() {
 				}, nil
 			}
 
-			return nil, xerrors.Errorf("unknown method: %v", method)
+			return nil, fmt.Errorf("unknown method: %v", method)
 		})
 
 	receiptResponse := []*jsonrpc.Response{
@@ -195,7 +196,7 @@ func (s *polygonClientTestSuite) TestPolygonTest_GetBlockByHeight_TransactionWit
 					}, nil
 				}
 
-				return nil, xerrors.Errorf("unknown tracer: %v", tracer)
+				return nil, fmt.Errorf("unknown tracer: %v", tracer)
 			}
 
 			if method == ethBorGetAuthorMethod {
@@ -204,7 +205,7 @@ func (s *polygonClientTestSuite) TestPolygonTest_GetBlockByHeight_TransactionWit
 				}, nil
 			}
 
-			return nil, xerrors.Errorf("unknown method: %v", method)
+			return nil, fmt.Errorf("unknown method: %v", method)
 		})
 
 	receiptResponse := []*jsonrpc.Response{
@@ -254,7 +255,7 @@ func (s *polygonClientTestSuite) TestPolygonTest_GetBlockByHeight_TransactionWit
 					}, nil
 				}
 
-				return nil, xerrors.Errorf("unknown tracer: %v", tracer)
+				return nil, fmt.Errorf("unknown tracer: %v", tracer)
 			}
 
 			if method == ethBorGetAuthorMethod {
@@ -263,7 +264,7 @@ func (s *polygonClientTestSuite) TestPolygonTest_GetBlockByHeight_TransactionWit
 				}, nil
 			}
 
-			return nil, xerrors.Errorf("unknown method: %v", method)
+			return nil, fmt.Errorf("unknown method: %v", method)
 		})
 
 	receiptResponse := []*jsonrpc.Response{
@@ -367,7 +368,7 @@ func (s *polygonClientTestSuite) TestPolygonTest_RetryBorAuthor_ServerErr() {
 					}, nil
 				}
 
-				return nil, xerrors.Errorf("unknown tracer: %v", tracer)
+				return nil, fmt.Errorf("unknown tracer: %v", tracer)
 
 			case ethBorGetAuthorMethod:
 				retryAttempts += 1
@@ -383,7 +384,7 @@ func (s *polygonClientTestSuite) TestPolygonTest_RetryBorAuthor_ServerErr() {
 				}, nil
 
 			default:
-				return nil, xerrors.Errorf("unknown method: %v", method)
+				return nil, fmt.Errorf("unknown method: %v", method)
 			}
 		})
 
@@ -444,7 +445,7 @@ func (s *polygonClientTestSuite) TestRetryTraceBlock_NotFound() {
 				}
 
 			default:
-				return nil, xerrors.Errorf("unknown method: %v", method)
+				return nil, fmt.Errorf("unknown method: %v", method)
 			}
 		})
 
@@ -494,7 +495,7 @@ func (s *polygonClientTestSuite) TestRetryTraceBlock_ExecutionAborted() {
 				}
 
 			default:
-				return nil, xerrors.Errorf("unknown method: %v", method)
+				return nil, fmt.Errorf("unknown method: %v", method)
 			}
 		})
 
@@ -536,7 +537,7 @@ func (s *polygonClientTestSuite) TestRetryTraceBlock_RetryLimitExceeded() {
 				}
 
 			default:
-				return nil, xerrors.Errorf("unknown method: %v", method)
+				return nil, fmt.Errorf("unknown method: %v", method)
 			}
 		})
 
@@ -550,7 +551,7 @@ func (s *polygonClientTestSuite) TestRetryTraceBlock_RetryLimitExceeded() {
 
 	_, err := s.client.GetBlockByHash(context.Background(), tag, ethereumHeight, ethereumHash)
 	require.Error(err)
-	require.True(xerrors.Is(err, internal.ErrBlockNotFound))
+	require.True(errors.Is(err, internal.ErrBlockNotFound))
 }
 
 func (s *polygonClientTestSuite) TestRetryTraceTransaction() {
@@ -596,10 +597,10 @@ func (s *polygonClientTestSuite) TestRetryTraceTransaction() {
 					}, nil
 				}
 
-				return nil, xerrors.Errorf("unknown tracer: %v", tracer)
+				return nil, fmt.Errorf("unknown tracer: %v", tracer)
 
 			default:
-				return nil, xerrors.Errorf("unknown method: %v", method)
+				return nil, fmt.Errorf("unknown method: %v", method)
 			}
 		})
 
@@ -660,10 +661,10 @@ func (s *polygonClientTestSuite) TestRetryTraceTransaction_RetryLimitExceeded() 
 					}
 				}
 
-				return nil, xerrors.Errorf("unknown tracer: %v", tracer)
+				return nil, fmt.Errorf("unknown tracer: %v", tracer)
 
 			default:
-				return nil, xerrors.Errorf("unknown method: %v", method)
+				return nil, fmt.Errorf("unknown method: %v", method)
 			}
 		})
 
@@ -677,7 +678,7 @@ func (s *polygonClientTestSuite) TestRetryTraceTransaction_RetryLimitExceeded() 
 
 	_, err := s.client.GetBlockByHeight(context.Background(), tag, 11322000, internal.WithBestEffort())
 	require.Error(err)
-	require.True(xerrors.Is(err, internal.ErrBlockNotFound))
+	require.True(errors.Is(err, internal.ErrBlockNotFound))
 }
 
 func (s *polygonClientTestSuite) TestRetryBatchGetBlockMetadata() {

--- a/internal/blockchain/client/internal/client.go
+++ b/internal/blockchain/client/internal/client.go
@@ -2,10 +2,11 @@ package internal
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"go.uber.org/fx"
 	"go.uber.org/zap"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/blockchain/parser"
 	"github.com/coinbase/chainstorage/internal/utils/fxparams"
@@ -101,8 +102,8 @@ const (
 )
 
 var (
-	ErrBlockNotFound  = xerrors.New("block not found")
-	ErrNotImplemented = xerrors.New("not implemented")
+	ErrBlockNotFound  = errors.New("block not found")
+	ErrNotImplemented = errors.New("not implemented")
 )
 
 func NewClient(params Params) (Result, error) {
@@ -145,7 +146,7 @@ func NewClient(params Params) (Result, error) {
 		}
 	}
 	if factory == nil {
-		return Result{}, xerrors.Errorf("client is not implemented: blockchain(%v)-sidechain(%v)", blockchain, sidechain)
+		return Result{}, fmt.Errorf("client is not implemented: blockchain(%v)-sidechain(%v)", blockchain, sidechain)
 	}
 
 	scope := params.Metrics

--- a/internal/blockchain/client/internal/interceptors.go
+++ b/internal/blockchain/client/internal/interceptors.go
@@ -2,11 +2,11 @@ package internal
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/uber-go/tally/v4"
 	"go.uber.org/zap"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/blockchain/parser"
 	"github.com/coinbase/chainstorage/internal/config"
@@ -89,7 +89,7 @@ func (p *parserInterceptor) UpgradeBlock(ctx context.Context, block *api.Block, 
 	}
 
 	if newTag != newBlock.Metadata.Tag {
-		return nil, xerrors.Errorf("unexpected tag: expected=%v, actual=%v", newTag, block.Metadata.Tag)
+		return nil, fmt.Errorf("unexpected tag: expected=%v, actual=%v", newTag, block.Metadata.Tag)
 	}
 
 	return newBlock, nil
@@ -106,24 +106,24 @@ func (p *parserInterceptor) GetAccountProof(ctx context.Context, req *api.GetVer
 func (p *parserInterceptor) validateBlock(ctx context.Context, block *api.Block, tag uint32, height uint64, hash string) error {
 	metadata := block.Metadata
 	if metadata == nil {
-		return xerrors.New("block metadata is null")
+		return errors.New("block metadata is null")
 	}
 
 	if metadata.Tag != tag {
-		return xerrors.Errorf("expected tag %v in metadata: {%+v}", tag, metadata)
+		return fmt.Errorf("expected tag %v in metadata: {%+v}", tag, metadata)
 	}
 
 	if metadata.Height != height {
-		return xerrors.Errorf("expected height %v in metadata: {%+v}", height, metadata)
+		return fmt.Errorf("expected height %v in metadata: {%+v}", height, metadata)
 	}
 
 	if hash != "" && metadata.Hash != hash {
-		return xerrors.Errorf("expected hash %v in metadata: {%+v}", hash, metadata)
+		return fmt.Errorf("expected hash %v in metadata: {%+v}", hash, metadata)
 	}
 
 	nativeBlock, err := p.parser.ParseNativeBlock(ctx, block)
 	if err != nil {
-		return xerrors.Errorf("failed to parse block to native format {%+v}: %w", metadata, err)
+		return fmt.Errorf("failed to parse block to native format {%+v}: %w", metadata, err)
 	}
 
 	if p.config.Chain.Feature.BlockValidationEnabled {
@@ -136,7 +136,7 @@ func (p *parserInterceptor) validateBlock(ctx context.Context, block *api.Block,
 			if p.config.Chain.Feature.BlockValidationMuted {
 				return nil
 			}
-			return xerrors.Errorf("failed to validate block {%+v}: %w", metadata, err)
+			return fmt.Errorf("failed to validate block {%+v}: %w", metadata, err)
 		}
 	}
 

--- a/internal/blockchain/client/internal/interceptors_test.go
+++ b/internal/blockchain/client/internal/interceptors_test.go
@@ -2,6 +2,7 @@ package internal_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -9,7 +10,6 @@ import (
 	"go.uber.org/mock/gomock"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/blockchain/client/internal"
 	clientmocks "github.com/coinbase/chainstorage/internal/blockchain/client/mocks"
@@ -20,8 +20,8 @@ import (
 )
 
 var (
-	errParser          = xerrors.New("parser error")
-	errBlockValidation = xerrors.New("block validation failed")
+	errParser          = errors.New("parser error")
+	errBlockValidation = errors.New("block validation failed")
 )
 
 func TestParserInterceptor(t *testing.T) {
@@ -127,11 +127,11 @@ func TestParserInterceptor_ParserError(t *testing.T) {
 	ctx := context.Background()
 	_, err = newclt.GetBlockByHeight(ctx, tag, height)
 	require.Error(err)
-	require.True(xerrors.Is(err, errParser))
+	require.True(errors.Is(err, errParser))
 
 	_, err = newclt.GetBlockByHash(ctx, tag, height, hash)
 	require.Error(err)
-	require.True(xerrors.Is(err, errParser))
+	require.True(errors.Is(err, errParser))
 
 	_, err = newclt.UpgradeBlock(ctx, expected, newTag)
 	require.Error(err)

--- a/internal/blockchain/client/rosetta/rosetta.go
+++ b/internal/blockchain/client/rosetta/rosetta.go
@@ -505,7 +505,7 @@ func (c *rosettaClientWithRawBlockApiImpl) getBlockByHashRequest(hash string) ([
 
 	body, err := json.Marshal(request)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create getBlockByHashRequest: %w", request, err)
+		return nil, fmt.Errorf("failed to create getBlockByHashRequest (%v): %w", request, err)
 	}
 
 	return body, nil

--- a/internal/blockchain/client/solana/solana_test.go
+++ b/internal/blockchain/client/solana/solana_test.go
@@ -3,13 +3,13 @@ package solana
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/fx"
 	"go.uber.org/mock/gomock"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/blockchain/client/internal"
 	"github.com/coinbase/chainstorage/internal/blockchain/jsonrpc"
@@ -281,7 +281,7 @@ func (s *solanaClientTestSuite) TestGetBlockByHeight_NotFound() {
 
 	_, err := s.client.GetBlockByHeight(context.Background(), solanaTag, solanaHeight)
 	require.Error(err)
-	require.True(xerrors.Is(err, internal.ErrBlockNotFound), err.Error())
+	require.True(errors.Is(err, internal.ErrBlockNotFound), err.Error())
 }
 
 func (s *solanaClientTestSuite) TestGetBlockByHeight_Skipped() {

--- a/internal/blockchain/endpoints/client.go
+++ b/internal/blockchain/endpoints/client.go
@@ -5,8 +5,6 @@ import (
 	"net/http"
 	"strings"
 
-	"golang.org/x/xerrors"
-
 	"github.com/coinbase/chainstorage/internal/utils/ratelimiter"
 )
 
@@ -18,7 +16,7 @@ func (rt *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 	err := rt.rateLimiter.WaitN(req.Context(), 1)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to wait for rate limiting: %w", err)
+		return nil, fmt.Errorf("failed to wait for rate limiting: %w", err)
 	}
 	res, err := rt.base.RoundTrip(req)
 	return res, err

--- a/internal/blockchain/endpoints/endpoint_provider_test.go
+++ b/internal/blockchain/endpoints/endpoint_provider_test.go
@@ -2,6 +2,7 @@ package endpoints
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"net/http/cookiejar"
@@ -14,7 +15,6 @@ import (
 	"go.uber.org/fx/fxtest"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/config"
 	"github.com/coinbase/chainstorage/internal/utils/testutil"
@@ -212,7 +212,7 @@ func TestEndpointProvider_EmptyEndpoints(t *testing.T) {
 	_, err = ep.WithFailoverContext(ctx)
 	require.Equal([]string{"foo"}, getActiveEndpoints(ctx, ep))
 	require.Error(err)
-	require.True(xerrors.Is(err, ErrFailoverUnavailable))
+	require.True(errors.Is(err, ErrFailoverUnavailable))
 }
 
 func TestEndpointProvider_StickySessionCookieHash(t *testing.T) {

--- a/internal/blockchain/endpoints/failover_manager.go
+++ b/internal/blockchain/endpoints/failover_manager.go
@@ -2,9 +2,9 @@ package endpoints
 
 import (
 	"context"
+	"fmt"
 
 	"go.uber.org/fx"
-	"golang.org/x/xerrors"
 )
 
 type ClusterIdentity int
@@ -55,25 +55,25 @@ func (m *failoverManager) WithFailoverContext(ctx context.Context, cluster Clust
 	if cluster&MasterCluster != 0 {
 		ctx, err = m.master.WithFailoverContext(ctx)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to failover the master endpoint group: %w", err)
+			return nil, fmt.Errorf("failed to failover the master endpoint group: %w", err)
 		}
 	}
 	if cluster&SlaveCluster != 0 {
 		ctx, err = m.slave.WithFailoverContext(ctx)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to failover the slave endpoint group: %w", err)
+			return nil, fmt.Errorf("failed to failover the slave endpoint group: %w", err)
 		}
 	}
 	if cluster&ValidatorCluster != 0 {
 		ctx, err = m.validator.WithFailoverContext(ctx)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to failover the validator endpoint group: %w", err)
+			return nil, fmt.Errorf("failed to failover the validator endpoint group: %w", err)
 		}
 	}
 	if cluster&ConsensusCluster != 0 {
 		ctx, err = m.consensus.WithFailoverContext(ctx)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to failover the consensus endpoint group: %w", err)
+			return nil, fmt.Errorf("failed to failover the consensus endpoint group: %w", err)
 		}
 	}
 

--- a/internal/blockchain/endpoints/failover_manager_test.go
+++ b/internal/blockchain/endpoints/failover_manager_test.go
@@ -2,11 +2,11 @@ package endpoints
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/uber-go/tally/v4"
 	"go.uber.org/zap/zaptest"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/config"
 	"github.com/coinbase/chainstorage/internal/utils/testutil"
@@ -438,7 +438,7 @@ func TestFailoverManager_MasterUnavailable(t *testing.T) {
 	ctx := context.Background()
 	_, err = mgr.WithFailoverContext(ctx, MasterSlaveClusters)
 	require.Error(err)
-	require.True(xerrors.Is(err, ErrFailoverUnavailable))
+	require.True(errors.Is(err, ErrFailoverUnavailable))
 }
 
 func TestFailoverManager_SlaveUnavailable(t *testing.T) {
@@ -486,5 +486,5 @@ func TestFailoverManager_SlaveUnavailable(t *testing.T) {
 	ctx := context.Background()
 	_, err = mgr.WithFailoverContext(ctx, MasterSlaveClusters)
 	require.Error(err)
-	require.True(xerrors.Is(err, ErrFailoverUnavailable))
+	require.True(errors.Is(err, ErrFailoverUnavailable))
 }

--- a/internal/blockchain/endpoints/rosetta_endpoints.go
+++ b/internal/blockchain/endpoints/rosetta_endpoints.go
@@ -2,10 +2,10 @@ package endpoints
 
 import (
 	"context"
+	"fmt"
 
 	rc "github.com/coinbase/rosetta-sdk-go/client"
 	"go.uber.org/fx"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/utils/consts"
 )
@@ -44,22 +44,22 @@ type (
 func NewRosettaEndpointProvider(params RosettaEndpointsParams) (RosettaEndpointsResult, error) {
 	master, err := newRosettaEndpointProvider(params.Master)
 	if err != nil {
-		return RosettaEndpointsResult{}, xerrors.Errorf("failed to create master endpoint provider: %w", err)
+		return RosettaEndpointsResult{}, fmt.Errorf("failed to create master endpoint provider: %w", err)
 	}
 
 	slave, err := newRosettaEndpointProvider(params.Slave)
 	if err != nil {
-		return RosettaEndpointsResult{}, xerrors.Errorf("failed to create slave endpoint provider: %w", err)
+		return RosettaEndpointsResult{}, fmt.Errorf("failed to create slave endpoint provider: %w", err)
 	}
 
 	validator, err := newRosettaEndpointProvider(params.Validator)
 	if err != nil {
-		return RosettaEndpointsResult{}, xerrors.Errorf("failed to create validator endpoint provider: %w", err)
+		return RosettaEndpointsResult{}, fmt.Errorf("failed to create validator endpoint provider: %w", err)
 	}
 
 	consensus, err := newRosettaEndpointProvider(params.Consensus)
 	if err != nil {
-		return RosettaEndpointsResult{}, xerrors.Errorf("failed to create consensus endpoint provider: %w", err)
+		return RosettaEndpointsResult{}, fmt.Errorf("failed to create consensus endpoint provider: %w", err)
 	}
 
 	return RosettaEndpointsResult{
@@ -86,7 +86,7 @@ func newRosettaEndpointProvider(endpointProvider EndpointProvider) (RosettaEndpo
 func (p *rosettaEndpointProvider) GetEndpoint(ctx context.Context) (*Endpoint, *rc.APIClient, error) {
 	endpoint, err := p.endpointProvider.GetEndpoint(ctx)
 	if err != nil {
-		return nil, nil, xerrors.Errorf("failed to get rosetta endpoint: %w", err)
+		return nil, nil, fmt.Errorf("failed to get rosetta endpoint: %w", err)
 	}
 	return endpoint, p.clients[endpoint], nil
 }

--- a/internal/blockchain/integration_test/aptos/aptos_integration_test.go
+++ b/internal/blockchain/integration_test/aptos/aptos_integration_test.go
@@ -2,6 +2,7 @@ package aptos_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"testing"
@@ -10,7 +11,6 @@ import (
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/blockchain/client"
 	"github.com/coinbase/chainstorage/internal/blockchain/jsonrpc"
@@ -213,7 +213,7 @@ func (s *aptosTestSuite) TestGetBlockByHeight_NotFound() {
 	// Query the block height which is uint64_max.
 	_, err := s.client.GetBlockByHeight(ctx, aptosTag, math.MaxUint64)
 	require.Error(err)
-	require.True(xerrors.Is(err, client.ErrBlockNotFound), err.Error())
+	require.True(errors.Is(err, client.ErrBlockNotFound), err.Error())
 }
 
 func (s *aptosTestSuite) TestGetBlockByHash_Success() {

--- a/internal/blockchain/integration_test/arbitrum/arbitrum_integration_test.go
+++ b/internal/blockchain/integration_test/arbitrum/arbitrum_integration_test.go
@@ -2,13 +2,13 @@ package arbitrum_test
 
 import (
 	"context"
+	"errors"
 	"math"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/blockchain/client"
 	"github.com/coinbase/chainstorage/internal/blockchain/jsonrpc"
@@ -279,11 +279,11 @@ func (s *arbitrumIntegrationTestSuite) TestArbitrumGetBlock_NotFound() {
 
 	_, err := s.client.GetBlockByHeight(context.Background(), arbitrumTag, uint64(math.MaxInt64))
 	require.Error(err)
-	require.True(xerrors.Is(err, client.ErrBlockNotFound), err.Error())
+	require.True(errors.Is(err, client.ErrBlockNotFound), err.Error())
 
 	_, err = s.client.GetBlockByHash(context.Background(), arbitrumTag, uint64(math.MaxInt64), hashNotFound)
 	require.Error(err)
-	require.True(xerrors.Is(err, client.ErrBlockNotFound), err.Error())
+	require.True(errors.Is(err, client.ErrBlockNotFound), err.Error())
 }
 
 func (s *arbitrumIntegrationTestSuite) TestArbitrumGetBlock_AfterNitroUpgrade_GethNestedTraces() {

--- a/internal/blockchain/integration_test/bitcoin/bitcoin_integration_test.go
+++ b/internal/blockchain/integration_test/bitcoin/bitcoin_integration_test.go
@@ -2,11 +2,11 @@ package bitcoin_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/fx"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/blockchain/client"
 	"github.com/coinbase/chainstorage/internal/blockchain/jsonrpc"
@@ -167,11 +167,11 @@ func (s *bitcoinIntegrationTestSuite) TestBitcoinGetBlock_NotFound() {
 
 	_, err := s.client.GetBlockByHeight(context.Background(), btcTag, btcHeightNotFound)
 	require.Error(err)
-	require.True(xerrors.Is(err, client.ErrBlockNotFound), err.Error())
+	require.True(errors.Is(err, client.ErrBlockNotFound), err.Error())
 
 	_, err = s.client.GetBlockByHash(context.Background(), btcTag, btcHeightNotFound, btcHashNotFound)
 	require.Error(err)
-	require.True(xerrors.Is(err, client.ErrBlockNotFound), err.Error())
+	require.True(errors.Is(err, client.ErrBlockNotFound), err.Error())
 }
 
 func (s *bitcoinIntegrationTestSuite) TestBitcoinGetLatestHeight() {

--- a/internal/blockchain/integration_test/bsc/bsc_integration_test.go
+++ b/internal/blockchain/integration_test/bsc/bsc_integration_test.go
@@ -2,6 +2,7 @@ package bsc_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/coinbase/chainstorage/internal/blockchain/client"
@@ -17,7 +18,6 @@ import (
 
 	"go.uber.org/fx"
 	"go.uber.org/zap"
-	"golang.org/x/xerrors"
 )
 
 const (
@@ -319,7 +319,7 @@ func TestIntegrationBscGetBlock_NotFound(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			_, err := test.getBlock()
 			require.Error(err)
-			require.True(xerrors.Is(err, client.ErrBlockNotFound), err.Error())
+			require.True(errors.Is(err, client.ErrBlockNotFound), err.Error())
 		})
 	}
 }

--- a/internal/blockchain/integration_test/ethereum/ethereum_integration_test.go
+++ b/internal/blockchain/integration_test/ethereum/ethereum_integration_test.go
@@ -2,6 +2,7 @@ package ethereum_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"sync/atomic"
@@ -13,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
-	"golang.org/x/xerrors"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/coinbase/chainstorage/internal/blockchain/client"
@@ -332,11 +332,11 @@ func TestIntegrationEthereumGetBlock_NotFound(t *testing.T) {
 
 	_, err := deps.Client.GetBlockByHeight(context.Background(), ethereumTag, heightNotFound)
 	require.Error(err)
-	require.True(xerrors.Is(err, client.ErrBlockNotFound), err.Error())
+	require.True(errors.Is(err, client.ErrBlockNotFound), err.Error())
 
 	_, err = deps.Client.GetBlockByHash(context.Background(), ethereumTag, heightNotFound, hashNotFound)
 	require.Error(err)
-	require.True(xerrors.Is(err, client.ErrBlockNotFound), err.Error())
+	require.True(errors.Is(err, client.ErrBlockNotFound), err.Error())
 }
 
 func TestIntegrationEthereumGetBlock_Goerli(t *testing.T) {

--- a/internal/blockchain/integration_test/fantom/fantom_integration_test.go
+++ b/internal/blockchain/integration_test/fantom/fantom_integration_test.go
@@ -2,12 +2,12 @@ package fantom_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/blockchain/client"
 	"github.com/coinbase/chainstorage/internal/blockchain/jsonrpc"
@@ -229,9 +229,9 @@ func (s *fantomIntegrationTestSuite) TestFantomGetBlock_NotFound() {
 
 	_, err := s.client.GetBlockByHeight(context.Background(), fantomTag, heightNotFound)
 	require.Error(err)
-	require.True(xerrors.Is(err, client.ErrBlockNotFound), err.Error())
+	require.True(errors.Is(err, client.ErrBlockNotFound), err.Error())
 
 	_, err = s.client.GetBlockByHash(context.Background(), fantomTag, heightNotFound, hashNotFound)
 	require.Error(err)
-	require.True(xerrors.Is(err, client.ErrBlockNotFound), err.Error())
+	require.True(errors.Is(err, client.ErrBlockNotFound), err.Error())
 }

--- a/internal/blockchain/integration_test/polygon/polygon_integration_test.go
+++ b/internal/blockchain/integration_test/polygon/polygon_integration_test.go
@@ -2,12 +2,12 @@ package polygon_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/blockchain/client"
 	"github.com/coinbase/chainstorage/internal/blockchain/jsonrpc"
@@ -326,11 +326,11 @@ func (s *polygonIntegrationTestSuite) TestPolygonGetBlock_NotFound() {
 
 	_, err := s.client.GetBlockByHeight(context.Background(), maticTag, heightNotFound)
 	require.Error(err)
-	require.True(xerrors.Is(err, client.ErrBlockNotFound), err.Error())
+	require.True(errors.Is(err, client.ErrBlockNotFound), err.Error())
 
 	_, err = s.client.GetBlockByHash(context.Background(), maticTag, heightNotFound, hashNotFound)
 	require.Error(err)
-	require.True(xerrors.Is(err, client.ErrBlockNotFound), err.Error())
+	require.True(errors.Is(err, client.ErrBlockNotFound), err.Error())
 }
 
 func (s *polygonIntegrationTestSuite) TestPolygon_ValidateBlock() {

--- a/internal/blockchain/integration_test/rosetta/rosetta_integration_test.go
+++ b/internal/blockchain/integration_test/rosetta/rosetta_integration_test.go
@@ -2,6 +2,7 @@ package rosetta_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"sync/atomic"
@@ -10,7 +11,6 @@ import (
 
 	"go.uber.org/fx"
 	"go.uber.org/zap"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/utils/testutil"
 	"github.com/coinbase/chainstorage/protos/coinbase/c3/common"
@@ -229,11 +229,11 @@ func testGetRosettaBlock_NotFound(t *testing.T, asset rosettaTestAsset) {
 
 	_, err := deps.Client.GetBlockByHeight(context.Background(), asset.Tag, asset.InvalidBlockHeight)
 	require.Error(err)
-	require.True(xerrors.Is(err, client.ErrBlockNotFound), err.Error())
+	require.True(errors.Is(err, client.ErrBlockNotFound), err.Error())
 
 	_, err = deps.Client.GetBlockByHash(context.Background(), asset.Tag, asset.InvalidBlockHeight, asset.InvalidBlockHash)
 	require.Error(err)
-	require.True(xerrors.Is(err, client.ErrBlockNotFound), err.Error())
+	require.True(errors.Is(err, client.ErrBlockNotFound), err.Error())
 }
 
 func BenchmarkDogecoinRosettaGetBlockByHeight(b *testing.B) {
@@ -292,21 +292,21 @@ func BenchmarkDogecoinRosettaGetBlockByHeight(b *testing.B) {
 				app.Logger().Info("processing block", zap.Uint64("height", height))
 				rawBlock, err := deps.Client.GetBlockByHeight(context.Background(), 0, height)
 				if err != nil {
-					return xerrors.Errorf("failed to get block for height %d", height)
+					return fmt.Errorf("failed to get block for height %d", height)
 				}
 				if height != rawBlock.Metadata.Height {
-					return xerrors.Errorf(
+					return fmt.Errorf(
 						"rosetta block has the wrong height, expected: %d, actual: %d",
 						height,
 						rawBlock.Metadata.Height)
 				}
 				nativeBlock, err := deps.Parser.ParseNativeBlock(context.Background(), rawBlock)
 				if err != nil {
-					return xerrors.Errorf("failed to parse rosetta block to a native block %w", err)
+					return fmt.Errorf("failed to parse rosetta block to a native block %w", err)
 				}
 				block := nativeBlock.GetRosetta()
 				if block == nil {
-					return xerrors.Errorf("native block misses rosetta blob")
+					return fmt.Errorf("native block misses rosetta blob")
 				}
 				atomic.AddInt32(&processed, 1)
 			}

--- a/internal/blockchain/integration_test/solana/solana_integration_test.go
+++ b/internal/blockchain/integration_test/solana/solana_integration_test.go
@@ -2,6 +2,7 @@ package solana_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/btcsuite/btcd/btcutil/base58"
@@ -9,7 +10,6 @@ import (
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/blockchain/client"
 	"github.com/coinbase/chainstorage/internal/blockchain/jsonrpc"
@@ -801,7 +801,7 @@ func (s *solanaTestSuite) TestGetBlockByHeight_NotFound() {
 	ctx := context.Background()
 	_, err := s.client.GetBlockByHeight(ctx, solanaTag, solanaBlockNumberNotFound)
 	require.Error(err)
-	require.True(xerrors.Is(err, client.ErrBlockNotFound), err.Error())
+	require.True(errors.Is(err, client.ErrBlockNotFound), err.Error())
 }
 
 func (s *solanaTestSuite) TestGetBlockByHeight_TransactionErr() {

--- a/internal/blockchain/jsonrpc/client_test.go
+++ b/internal/blockchain/jsonrpc/client_test.go
@@ -3,6 +3,8 @@ package jsonrpc_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -12,7 +14,6 @@ import (
 
 	"go.uber.org/fx"
 	"go.uber.org/mock/gomock"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/blockchain/jsonrpc"
 	jsonrpcmocks "github.com/coinbase/chainstorage/internal/blockchain/jsonrpc/mocks"
@@ -114,7 +115,7 @@ func TestCall_HTTPError(t *testing.T) {
 	require.Contains(err.Error(), "endpoint=node_name")
 
 	var errHTTP *jsonrpc.HTTPError
-	require.True(xerrors.As(err, &errHTTP))
+	require.True(errors.As(err, &errHTTP))
 	require.Equal(400, errHTTP.Code)
 	require.Equal("an unexpected error occurred", errHTTP.Response)
 }
@@ -159,7 +160,7 @@ func TestCall_RPCError(t *testing.T) {
 	require.Contains(err.Error(), "endpoint=node_name")
 
 	var errRPC *jsonrpc.RPCError
-	require.True(xerrors.As(err, &errRPC))
+	require.True(errors.As(err, &errRPC))
 	require.Equal(8, errRPC.Code)
 	require.Equal("an unexpected error occurred", errRPC.Message)
 }
@@ -202,7 +203,7 @@ func TestCall_AllowsRPCError(t *testing.T) {
 	)
 	require.NoError(err)
 	var errRPC *jsonrpc.RPCError
-	require.True(xerrors.As(response.Error, &errRPC))
+	require.True(errors.As(response.Error, &errRPC))
 	require.Equal(8, errRPC.Code)
 	require.Equal("an unexpected error occurred", errRPC.Message)
 }
@@ -246,7 +247,7 @@ func TestCall_RPCError_StatusNotOK(t *testing.T) {
 	require.Nil(result)
 
 	var errRPC *jsonrpc.RPCError
-	require.True(xerrors.As(err, &errRPC))
+	require.True(errors.As(err, &errRPC))
 	require.Equal(8, errRPC.Code)
 	require.Equal("an unexpected error occurred", errRPC.Message)
 }
@@ -290,7 +291,7 @@ func TestCall_RPCError_TooManyRequests(t *testing.T) {
 	require.Nil(result)
 
 	var errRPC *jsonrpc.RPCError
-	require.True(xerrors.As(err, &errRPC))
+	require.True(errors.As(err, &errRPC))
 	require.Equal(429, errRPC.Code)
 	require.Equal("too many requests", errRPC.Message)
 }
@@ -379,7 +380,7 @@ func TestCall_RPCError_StatusNotOK_WithCustomizedAttempts(t *testing.T) {
 	require.Nil(result)
 
 	var errRPC *jsonrpc.RPCError
-	require.True(xerrors.As(err, &errRPC))
+	require.True(errors.As(err, &errRPC))
 	require.Equal(8, errRPC.Code)
 	require.Equal("an unexpected error occurred", errRPC.Message)
 }
@@ -394,7 +395,7 @@ func TestCall_URLError(t *testing.T) {
 	urlError := &url.Error{
 		Op:  "Post",
 		URL: "foo.com",
-		Err: xerrors.Errorf("a test error"),
+		Err: fmt.Errorf("a test error"),
 	}
 	httpClient.EXPECT().Do(gomock.Any()).Return(nil, urlError).Times(retry.DefaultMaxAttempts)
 
@@ -422,8 +423,8 @@ func TestCall_URLError(t *testing.T) {
 	require.Nil(result)
 
 	var uerr *url.Error
-	require.False(xerrors.As(err, &uerr))
-	errMsg := xerrors.Unwrap(err).Error()
+	require.False(errors.As(err, &uerr))
+	errMsg := errors.Unwrap(err).Error()
 	require.Contains(errMsg, "a test error")
 	require.NotContains(errMsg, "foo.com")
 }
@@ -525,7 +526,7 @@ func TestBatchCall_RPCError(t *testing.T) {
 	require.Error(err)
 
 	var errRPC *jsonrpc.RPCError
-	require.True(xerrors.As(err, &errRPC))
+	require.True(errors.As(err, &errRPC))
 	require.Equal(-3, errRPC.Code)
 	require.Equal("an unexpected error occurred", errRPC.Message)
 }
@@ -580,7 +581,7 @@ func TestBatchCall_AllowsRPCError(t *testing.T) {
 	require.Nil(responses[2].Error)
 
 	var errRPC *jsonrpc.RPCError
-	require.True(xerrors.As(responses[1].Error, &errRPC))
+	require.True(errors.As(responses[1].Error, &errRPC))
 	require.Equal(-3, errRPC.Code)
 	require.Equal("an unexpected error occurred", errRPC.Message)
 }
@@ -753,7 +754,7 @@ func TestBatchCall_URLError(t *testing.T) {
 	urlError := &url.Error{
 		Op:  "Post",
 		URL: "foo.com",
-		Err: xerrors.Errorf("a test error"),
+		Err: fmt.Errorf("a test error"),
 	}
 	httpClient.EXPECT().Do(gomock.Any()).Return(nil, urlError).Times(retry.DefaultMaxAttempts)
 
@@ -782,8 +783,8 @@ func TestBatchCall_URLError(t *testing.T) {
 	require.Error(err)
 
 	var uerr *url.Error
-	require.False(xerrors.As(err, &uerr))
-	errMsg := xerrors.Unwrap(err).Error()
+	require.False(errors.As(err, &uerr))
+	errMsg := errors.Unwrap(err).Error()
 	require.Contains(errMsg, "a test error")
 	require.NotContains(errMsg, "foo.com")
 }

--- a/internal/blockchain/parser/aptos/aptos_native.go
+++ b/internal/blockchain/parser/aptos/aptos_native.go
@@ -652,7 +652,7 @@ func (p *aptosNativeParserImpl) parseTransactions(blockHeight uint64, transactio
 				return nil, fmt.Errorf("failed to parse validator transactions with hash=%s: %w", transactionInfo.TransactionHash, err)
 			}
 		default:
-			return nil, fmt.Errorf("failed to parse transaction_hash=%s, unknown type: %w", transactionInfo.TransactionHash, transactionInfo.Type)
+			return nil, fmt.Errorf("failed to parse transaction_hash=%s, unknown type: %s: %w", transactionInfo.TransactionHash, transactionInfo.Type, err)
 		}
 
 		result[i] = transaction
@@ -897,7 +897,7 @@ func (p *aptosNativeParserImpl) parseChanges(changes []json.RawMessage) ([]*api.
 			}
 
 		default:
-			return nil, fmt.Errorf("failed to parse change type: %w", wcType.Type)
+			return nil, fmt.Errorf("failed to parse change type %s", wcType.Type)
 		}
 	}
 

--- a/internal/blockchain/parser/ethereum/base_rosetta.go
+++ b/internal/blockchain/parser/ethereum/base_rosetta.go
@@ -2,10 +2,11 @@ package ethereum
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"math/big"
 
 	"go.uber.org/zap"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/blockchain/parser/ethereum/types"
 	"github.com/coinbase/chainstorage/internal/blockchain/parser/internal"
@@ -65,12 +66,12 @@ func (p *baseRosettaParserImpl) ParseBlock(ctx context.Context, rawBlock *api.Bl
 	nativeBlock, err := p.nativeParser.ParseBlock(ctx, rawBlock)
 
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse block into native format: %w", err)
+		return nil, fmt.Errorf("failed to parse block into native format: %w", err)
 	}
 
 	block := nativeBlock.GetEthereum()
 	if block == nil {
-		return nil, xerrors.New("failed to find ethereum block")
+		return nil, errors.New("failed to find ethereum block")
 	}
 
 	blockIdentifier := &rosetta.BlockIdentifier{
@@ -85,7 +86,7 @@ func (p *baseRosettaParserImpl) ParseBlock(ctx context.Context, rawBlock *api.Bl
 
 	transactions, err := p.getRosettaTransactions(block, rawBlock.GetEthereum())
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse block transactions: %w", err)
+		return nil, fmt.Errorf("failed to parse block transactions: %w", err)
 	}
 
 	return &api.RosettaBlock{
@@ -121,7 +122,7 @@ func (p *baseRosettaParserImpl) feeOps(transaction *api.EthereumTransaction, min
 
 	feeDetails, err := getFeeDetails(transaction, block)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to calculate base fee details: %w", err)
+		return nil, fmt.Errorf("failed to calculate base fee details: %w", err)
 	}
 
 	sequencerFeeAmount := feeDetails.feeAmount

--- a/internal/blockchain/parser/ethereum/beacon/native_utils.go
+++ b/internal/blockchain/parser/ethereum/beacon/native_utils.go
@@ -6,28 +6,27 @@ import (
 	"strconv"
 
 	"github.com/prysmaticlabs/prysm/v4/math"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/blockchain/parser/internal"
 )
 
 func (q *Quantity) UnmarshalJSON(input []byte) error {
 	if len(input) == 0 {
-		return xerrors.Errorf("input missing")
+		return fmt.Errorf("input missing")
 	}
 
 	var str string
 	if err := json.Unmarshal(input, &str); err != nil {
-		return xerrors.Errorf("failed to unmarshal Quantity into string: %w", err)
+		return fmt.Errorf("failed to unmarshal Quantity into string: %w", err)
 	}
 
 	if str == "" {
-		return xerrors.Errorf("empty string")
+		return fmt.Errorf("empty string")
 	}
 
 	val, err := strconv.ParseUint(str, 10, 64)
 	if err != nil {
-		return xerrors.Errorf("invalid value %v: %w", str, err)
+		return fmt.Errorf("invalid value %v: %w", str, err)
 	}
 	*q = Quantity(val)
 
@@ -44,16 +43,16 @@ func (q Quantity) Value() uint64 {
 
 func (t *ExecutionTransaction) UnmarshalJSON(input []byte) error {
 	if len(input) == 0 {
-		return xerrors.Errorf("input missing")
+		return fmt.Errorf("input missing")
 	}
 
 	var s string
 	if err := json.Unmarshal(input, &s); err != nil {
-		return xerrors.Errorf("failed to unmarshal ExecutionTransaction: %w", err)
+		return fmt.Errorf("failed to unmarshal ExecutionTransaction: %w", err)
 	}
 
 	if !internal.Has0xPrefix(s) {
-		return xerrors.Errorf("missing 0x prefix")
+		return fmt.Errorf("missing 0x prefix")
 	}
 
 	*t = []byte(s)
@@ -67,16 +66,16 @@ func (t ExecutionTransaction) MarshalJSON() ([]byte, error) {
 
 func (b *Blob) UnmarshalJSON(input []byte) error {
 	if len(input) == 0 {
-		return xerrors.Errorf("input missing")
+		return fmt.Errorf("input missing")
 	}
 
 	var s string
 	if err := json.Unmarshal(input, &s); err != nil {
-		return xerrors.Errorf("failed to unmarshal Blob: %w", err)
+		return fmt.Errorf("failed to unmarshal Blob: %w", err)
 	}
 
 	if !internal.Has0xPrefix(s) {
-		return xerrors.Errorf("missing 0x prefix")
+		return fmt.Errorf("missing 0x prefix")
 	}
 
 	*b = []byte(s)
@@ -93,7 +92,7 @@ func (b Blob) MarshalJSON() ([]byte, error) {
 func calculateEpoch(slot uint64) (uint64, error) {
 	epoch, err := math.Div64(slot, SlotsPerEpoch)
 	if err != nil {
-		return 0, xerrors.Errorf("failed to calculate epoch for slot=%d: %w", slot, err)
+		return 0, fmt.Errorf("failed to calculate epoch for slot=%d: %w", slot, err)
 	}
 	return epoch, nil
 }

--- a/internal/blockchain/parser/ethereum/ethereum_rosetta.go
+++ b/internal/blockchain/parser/ethereum/ethereum_rosetta.go
@@ -2,13 +2,13 @@ package ethereum
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"strconv"
 	"strings"
 
 	"go.uber.org/zap"
-	"golang.org/x/xerrors"
 	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/coinbase/chainstorage/internal/blockchain/bootstrap"
@@ -77,12 +77,12 @@ func (p *ethereumRosettaParserImpl) ParseBlock(ctx context.Context, rawBlock *ap
 	nativeBlock, err := p.nativeParser.ParseBlock(ctx, rawBlock)
 
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse block into native format: %w", err)
+		return nil, fmt.Errorf("failed to parse block into native format: %w", err)
 	}
 
 	block := nativeBlock.GetEthereum()
 	if block == nil {
-		return nil, xerrors.New("failed to find ethereum block")
+		return nil, errors.New("failed to find ethereum block")
 	}
 
 	blockIdentifier := &rosetta.BlockIdentifier{
@@ -97,7 +97,7 @@ func (p *ethereumRosettaParserImpl) ParseBlock(ctx context.Context, rawBlock *ap
 
 	transactions, err := p.getRosettaTransactions(block, rawBlock.GetEthereum())
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse block transactions: %w", err)
+		return nil, fmt.Errorf("failed to parse block transactions: %w", err)
 	}
 
 	if nativeBlock.Height == 0 {
@@ -110,7 +110,7 @@ func (p *ethereumRosettaParserImpl) ParseBlock(ctx context.Context, rawBlock *ap
 
 		genesisTransactions, err := p.getGenesisTransactions(genesisAllocation)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to generate genesis transactions: %w", err)
+			return nil, fmt.Errorf("failed to generate genesis transactions: %w", err)
 		}
 		transactions = append(transactions, genesisTransactions...)
 	}
@@ -261,7 +261,7 @@ func (p *ethereumRosettaParserImpl) createBlockRewardTransaction(block *api.Ethe
 func (p *ethereumRosettaParserImpl) feeOps(transaction *api.EthereumTransaction, miner string, block *api.EthereumBlock) ([]*rosetta.Operation, error) {
 	feeDetails, err := getFeeDetails(transaction, block)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to calculate ethereum fee details: %w", err)
+		return nil, fmt.Errorf("failed to calculate ethereum fee details: %w", err)
 	}
 	minerEarnedAmount := feeDetails.feeAmount
 	if feeDetails.feeBurned != nil {
@@ -339,7 +339,7 @@ func (p *ethereumRosettaParserImpl) getGenesisTransactions(allocations []*bootst
 		address := allo.AccountIdentifier.Address
 		_, err := internal.ChecksumAddress(address)
 		if err != nil {
-			return nil, xerrors.Errorf("%s is not a valid address", address)
+			return nil, fmt.Errorf("%s is not a valid address", address)
 		}
 		addressLower := strings.ToLower(address)
 

--- a/internal/blockchain/parser/ethereum/polygon_rosetta_test.go
+++ b/internal/blockchain/parser/ethereum/polygon_rosetta_test.go
@@ -2,6 +2,7 @@ package ethereum
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -9,7 +10,6 @@ import (
 	"go.uber.org/fx"
 	"go.uber.org/mock/gomock"
 	"go.uber.org/zap"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/blockchain/parser/internal"
 	"github.com/coinbase/chainstorage/internal/utils/fixtures"
@@ -478,7 +478,7 @@ func (s *polygonRosettaParserTestSuite) TestRosettaPolygonResponseParity() {
 
 func (s *polygonRosettaParserTestSuite) normalizeTransaction(expected *rosetta.Transaction, actual *rosetta.Transaction) error {
 	if len(expected.Operations) != len(actual.Operations) {
-		return xerrors.Errorf("operation size is different for transaction:%v", expected.TransactionIdentifier.Hash)
+		return fmt.Errorf("operation size is different for transaction:%v", expected.TransactionIdentifier.Hash)
 	}
 
 	for i := range expected.Operations {

--- a/internal/blockchain/parser/internal/checker.go
+++ b/internal/blockchain/parser/internal/checker.go
@@ -2,12 +2,12 @@ package internal
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
 	"github.com/uber-go/tally/v4"
 	"go.uber.org/zap"
-	"golang.org/x/xerrors"
 	"google.golang.org/protobuf/testing/protocmp"
 
 	"github.com/coinbase/chainstorage/internal/utils/log"
@@ -96,13 +96,13 @@ func (p *checkerImpl) CompareNativeBlocks(ctx context.Context, height uint64, ex
 	actualBlock.Timestamp = expectedBlock.Timestamp
 
 	if err := p.PreProcessor.PreProcessNativeBlock(expectedBlock, actualBlock); err != nil {
-		return xerrors.Errorf("failed to preprocess blocks: %w", err)
+		return fmt.Errorf("failed to preprocess blocks: %w", err)
 	}
 
 	if !proto.Equal(expectedBlock, actualBlock) {
 		diff := cmp.Diff(expectedBlock, actualBlock, protocmp.Transform())
 		return &ParityCheckFailedError{
-			Err:  xerrors.Errorf("parity issue detected with native blocks: height=%v", height),
+			Err:  fmt.Errorf("parity issue detected with native blocks: height=%v", height),
 			Diff: diff,
 		}
 	}

--- a/internal/blockchain/parser/internal/errors.go
+++ b/internal/blockchain/parser/internal/errors.go
@@ -1,12 +1,10 @@
 package internal
 
-import (
-	"golang.org/x/xerrors"
-)
+import "errors"
 
 var (
-	ErrInvalidChain      = xerrors.New("invalid chain")
-	ErrNotImplemented    = xerrors.New("not implemented")
-	ErrNotFound          = xerrors.New("not found")
-	ErrInvalidParameters = xerrors.New("invalid input parameters")
+	ErrInvalidChain      = errors.New("invalid chain")
+	ErrNotImplemented    = errors.New("not implemented")
+	ErrNotFound          = errors.New("not found")
+	ErrInvalidParameters = errors.New("invalid input parameters")
 )

--- a/internal/blockchain/parser/internal/interceptors.go
+++ b/internal/blockchain/parser/internal/interceptors.go
@@ -2,11 +2,11 @@ package internal
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/uber-go/tally/v4"
 	"go.uber.org/zap"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/utils/instrument"
 	api "github.com/coinbase/chainstorage/protos/coinbase/chainstorage"
@@ -46,7 +46,7 @@ func newInstrument(method string, scope tally.Scope, logger *zap.Logger) instrum
 		method,
 		instrument.WithLogger(logger, fmt.Sprintf("parser.%v", method)),
 		instrument.WithFilter(func(err error) bool {
-			return xerrors.Is(err, ErrNotImplemented)
+			return errors.Is(err, ErrNotImplemented)
 		}),
 	)
 }
@@ -57,7 +57,7 @@ func newInstrumentWithResult[T any](method string, scope tally.Scope, logger *za
 		method,
 		instrument.WithLogger(logger, fmt.Sprintf("parser.%v", method)),
 		instrument.WithFilter(func(err error) bool {
-			return xerrors.Is(err, ErrNotImplemented)
+			return errors.Is(err, ErrNotImplemented)
 		}),
 	)
 }

--- a/internal/blockchain/parser/internal/parser.go
+++ b/internal/blockchain/parser/internal/parser.go
@@ -2,9 +2,9 @@ package internal
 
 import (
 	"context"
+	"fmt"
 
 	"go.uber.org/fx"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/utils/fxparams"
 	"github.com/coinbase/chainstorage/internal/utils/log"
@@ -117,12 +117,12 @@ func NewParser(params Params) (Parser, error) {
 	}
 
 	if factory == nil {
-		return nil, xerrors.Errorf("parser is not implemented: blockchain(%v)-sidechain(%v)", blockchain, sidechain)
+		return nil, fmt.Errorf("parser is not implemented: blockchain(%v)-sidechain(%v)", blockchain, sidechain)
 	}
 
 	parser, err := factory.NewParser()
 	if err != nil {
-		return nil, xerrors.Errorf("failed to create parser: %w", err)
+		return nil, fmt.Errorf("failed to create parser: %w", err)
 	}
 
 	scope := params.Metrics

--- a/internal/blockchain/parser/internal/parser_builder.go
+++ b/internal/blockchain/parser/internal/parser_builder.go
@@ -1,8 +1,9 @@
 package internal
 
 import (
+	"fmt"
+
 	"go.uber.org/fx"
-	"golang.org/x/xerrors"
 )
 
 type (
@@ -76,17 +77,17 @@ func (b *ParserBuilder) Build() fx.Option {
 func (f *parserFactoryImpl) NewParser() (Parser, error) {
 	nativeParser, err := f.nativeParserFactory(f.params)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to create native parser: %w", err)
+		return nil, fmt.Errorf("failed to create native parser: %w", err)
 	}
 
 	rosettaParser, err := f.rosettaParserFactory(f.params, nativeParser)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to create rosetta parser: %w", err)
+		return nil, fmt.Errorf("failed to create rosetta parser: %w", err)
 	}
 
 	checker, err := f.checkerFactory(f.params)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to create checker: %w", err)
+		return nil, fmt.Errorf("failed to create checker: %w", err)
 	}
 
 	validator := f.validatorFactory(f.params)

--- a/internal/blockchain/parser/internal/utils.go
+++ b/internal/blockchain/parser/internal/utils.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 
 	"github.com/btcsuite/btcd/btcutil/base58"
+	"github.com/cockroachdb/errors"
 	geth "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"golang.org/x/xerrors"
 
 	api "github.com/coinbase/chainstorage/protos/coinbase/chainstorage"
 )
@@ -66,7 +66,7 @@ func ValidateChain(blocks []*api.BlockMetadata, lastBlock *api.BlockMetadata) er
 		// Check block height continuous only when its parent height is available.
 		if lastBlock != nil && !lastBlock.Skipped && currBlock.ParentHash != "" {
 			if lastBlock.Hash != currBlock.ParentHash || (currBlock.ParentHeight != 0 && lastBlock.Height != currBlock.ParentHeight) {
-				return xerrors.Errorf("chain is not continuous (last={%+v}, curr={%+v}): %w", lastBlock, currBlock, ErrInvalidChain)
+				return fmt.Errorf("chain is not continuous (last={%+v}, curr={%+v}): %w", lastBlock, currBlock, ErrInvalidChain)
 			}
 		}
 
@@ -80,12 +80,12 @@ func ValidateChain(blocks []*api.BlockMetadata, lastBlock *api.BlockMetadata) er
 func HexToBig(hex string) (*big.Int, error) {
 	cleanedHex, err := CleanHexString(hex)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to clean hex string %v: %w", hex, err)
+		return nil, fmt.Errorf("failed to clean hex string %v: %w", hex, err)
 	}
 
 	val, err := hexutil.DecodeBig(cleanedHex)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to decode big number %v: %w", hex, err)
+		return nil, fmt.Errorf("failed to decode big number %v: %w", hex, err)
 	}
 
 	return val, nil
@@ -96,7 +96,7 @@ func CleanHexString(hex string) (string, error) {
 	var cleaned string
 
 	if !Has0xPrefix(hex) {
-		return "", xerrors.Errorf("string missing 0x prefix: %v", hex)
+		return "", fmt.Errorf("string missing 0x prefix: %v", hex)
 	}
 
 	cleaned = hex[2:]
@@ -118,7 +118,7 @@ func CleanAddress(address string) (string, error) {
 	var cleaned string
 
 	if len(address) < ethHexAddressLength {
-		return "", xerrors.Errorf("address too short: %v", address)
+		return "", fmt.Errorf("address too short: %v", address)
 	}
 
 	cleaned = address[len(address)-ethHexAddressLength:]
@@ -138,8 +138,8 @@ type truncatedError struct {
 }
 
 var (
-	_ error           = (*truncatedError)(nil)
-	_ xerrors.Wrapper = (*truncatedError)(nil)
+	_ error          = (*truncatedError)(nil)
+	_ errors.Wrapper = (*truncatedError)(nil)
 )
 
 func NewTruncatedError(err error) error {
@@ -177,7 +177,7 @@ func DecodeBase58(s string) []byte {
 func BigInt(value string) (*big.Int, error) {
 	parsedVal, ok := new(big.Int).SetString(value, 10)
 	if !ok {
-		return nil, xerrors.Errorf("%s is not an integer", value)
+		return nil, fmt.Errorf("%s is not an integer", value)
 	}
 	return parsedVal, nil
 }
@@ -185,7 +185,7 @@ func BigInt(value string) (*big.Int, error) {
 func ChecksumAddress(address string) (string, error) {
 	mixedCaseAddress, err := geth.NewMixedcaseAddressFromString(address)
 	if err != nil {
-		return "", xerrors.Errorf("fail to normalize address=%s: %w", address, err)
+		return "", fmt.Errorf("fail to normalize address=%s: %w", address, err)
 	}
 	return mixedCaseAddress.Address().Hex(), nil
 }

--- a/internal/blockchain/parser/module_test.go
+++ b/internal/blockchain/parser/module_test.go
@@ -2,10 +2,10 @@ package parser
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"go.uber.org/fx"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/blockchain/parser/internal"
 	"github.com/coinbase/chainstorage/internal/config"
@@ -56,9 +56,9 @@ func TestParserNotImplemented(t *testing.T) {
 		_, err := parser.ParseRosettaBlock(context.Background(), block)
 		require.Error(err)
 		if cfg.Chain.Feature.RosettaParser {
-			require.False(xerrors.Is(err, internal.ErrNotImplemented), "'%v' should NOT be ErrNotImplemented", err.Error())
+			require.False(errors.Is(err, internal.ErrNotImplemented), "'%v' should NOT be ErrNotImplemented", err.Error())
 		} else {
-			require.True(xerrors.Is(err, internal.ErrNotImplemented), "'%v' should be ErrNotImplemented", err.Error())
+			require.True(errors.Is(err, internal.ErrNotImplemented), "'%v' should be ErrNotImplemented", err.Error())
 		}
 	})
 }

--- a/internal/blockchain/parser/rosetta/rosetta_native.go
+++ b/internal/blockchain/parser/rosetta/rosetta_native.go
@@ -2,9 +2,10 @@ package rosetta
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"go.uber.org/zap"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/blockchain/parser/internal"
 	"github.com/coinbase/chainstorage/internal/utils/log"
@@ -26,27 +27,27 @@ func NewRosettaNativeParser(params internal.ParserParams, opts ...internal.Parse
 func (p *rosettaNativeParserImpl) ParseBlock(ctx context.Context, rawBlock *api.Block) (*api.NativeBlock, error) {
 	metadata := rawBlock.GetMetadata()
 	if metadata == nil {
-		return nil, xerrors.New("metadata not found")
+		return nil, errors.New("metadata not found")
 	}
 
 	blobdata := rawBlock.GetRosetta()
 	if blobdata == nil {
-		return nil, xerrors.New("blobdata not found for rosetta")
+		return nil, errors.New("blobdata not found for rosetta")
 	}
 
 	rosettaBlock, err := ParseRosettaBlock(blobdata.Header)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse rosetta block: %w", err)
+		return nil, fmt.Errorf("failed to parse rosetta block: %w", err)
 	}
 
 	otherTransactions, err := ParseOtherTransactions(blobdata.OtherTransactions)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse rosetta other transactions: %w", err)
+		return nil, fmt.Errorf("failed to parse rosetta other transactions: %w", err)
 	}
 
 	if len(otherTransactions) > 0 {
 		if rosettaBlock == nil {
-			return nil, xerrors.Errorf("rosetta block is nil while having other transactions")
+			return nil, fmt.Errorf("rosetta block is nil while having other transactions")
 		}
 		rosettaBlock.Transactions = append(rosettaBlock.Transactions, otherTransactions...)
 	}

--- a/internal/blockchain/parser/rosetta/rosetta_rosetta.go
+++ b/internal/blockchain/parser/rosetta/rosetta_rosetta.go
@@ -2,9 +2,10 @@ package rosetta
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"go.uber.org/zap"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/blockchain/parser/internal"
 	"github.com/coinbase/chainstorage/internal/config"
@@ -40,13 +41,13 @@ func (p *rosettaRosettaParserImpl) ParseBlock(ctx context.Context, rawBlock *api
 func (p *rosettaRosettaParserImpl) parseBlockFromNative(ctx context.Context, rawBlock *api.Block) (*api.RosettaBlock, error) {
 	nativeBlock, err := p.nativeParser.ParseBlock(ctx, rawBlock)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse block into native format: %w", err)
+		return nil, fmt.Errorf("failed to parse block into native format: %w", err)
 	}
 
 	rosettaBlock := nativeBlock.GetRosetta()
 
 	if rosettaBlock == nil {
-		return nil, xerrors.Errorf("the rosetta block is not found")
+		return nil, fmt.Errorf("the rosetta block is not found")
 	}
 
 	return &api.RosettaBlock{
@@ -57,27 +58,27 @@ func (p *rosettaRosettaParserImpl) parseBlockFromNative(ctx context.Context, raw
 func (p *rosettaRosettaParserImpl) parseBlockFromRosetta(ctx context.Context, rawBlock *api.Block) (*api.RosettaBlock, error) {
 	metadata := rawBlock.GetMetadata()
 	if metadata == nil {
-		return nil, xerrors.New("metadata not found")
+		return nil, errors.New("metadata not found")
 	}
 
 	blobdata := rawBlock.GetRosetta()
 	if blobdata == nil {
-		return nil, xerrors.New("blobData not found for rosetta")
+		return nil, errors.New("blobData not found for rosetta")
 	}
 
 	rosettaBlock, err := ParseRosettaBlock(blobdata.Header)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse rosetta block: %w", err)
+		return nil, fmt.Errorf("failed to parse rosetta block: %w", err)
 	}
 
 	otherTransactions, err := ParseOtherTransactions(blobdata.OtherTransactions)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse rosetta other transactions: %w", err)
+		return nil, fmt.Errorf("failed to parse rosetta other transactions: %w", err)
 	}
 
 	if len(otherTransactions) > 0 {
 		if rosettaBlock == nil {
-			return nil, xerrors.Errorf("rosetta block is nil while having other transactions")
+			return nil, fmt.Errorf("rosetta block is nil while having other transactions")
 		}
 		rosettaBlock.Transactions = append(rosettaBlock.Transactions, otherTransactions...)
 	}

--- a/internal/blockchain/parser/rosetta/utils.go
+++ b/internal/blockchain/parser/rosetta/utils.go
@@ -2,9 +2,9 @@ package rosetta
 
 import (
 	"encoding/json"
+	"fmt"
 
 	sdk "github.com/coinbase/rosetta-sdk-go/types"
-	"golang.org/x/xerrors"
 
 	rosetta "github.com/coinbase/chainstorage/protos/coinbase/crypto/rosetta/types"
 )
@@ -12,7 +12,7 @@ import (
 func ParseRosettaBlock(data []byte) (*rosetta.Block, error) {
 	var blockResponse sdk.BlockResponse
 	if err := json.Unmarshal(data, &blockResponse); err != nil {
-		return nil, xerrors.Errorf("failed to parse block response: %w", err)
+		return nil, fmt.Errorf("failed to parse block response: %w", err)
 	}
 
 	block := blockResponse.Block
@@ -22,7 +22,7 @@ func ParseRosettaBlock(data []byte) (*rosetta.Block, error) {
 
 	rosettaBlock, err := rosetta.FromSDKBlock(block)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse rosetta sdk block: %w", err)
+		return nil, fmt.Errorf("failed to parse rosetta sdk block: %w", err)
 	}
 
 	return rosettaBlock, nil
@@ -33,13 +33,13 @@ func ParseOtherTransactions(data [][]byte) ([]*rosetta.Transaction, error) {
 	for i, rawTx := range data {
 		var transactionResponse sdk.BlockTransactionResponse
 		if err := json.Unmarshal(rawTx, &transactionResponse); err != nil {
-			return nil, xerrors.Errorf("failed to parse block transaction response: %w", err)
+			return nil, fmt.Errorf("failed to parse block transaction response: %w", err)
 		}
 
 		transaction := transactionResponse.Transaction
 		tx, err := rosetta.FromSDKTransaction(transaction)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to parse transaction of other transactions: %w", err)
+			return nil, fmt.Errorf("failed to parse transaction of other transactions: %w", err)
 		}
 
 		txs[i] = tx

--- a/internal/blockchain/parser/solana/solana_rosetta_test.go
+++ b/internal/blockchain/parser/solana/solana_rosetta_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/fx"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/blockchain/parser/internal"
 	"github.com/coinbase/chainstorage/internal/utils/fixtures"
@@ -362,7 +361,7 @@ func (s *solanaRosettaParserTestSuite) validateSolanaRosettaTransactionOperation
 			}
 			actualPostTokenBalances[key] = val.Add(val, amount)
 		} else {
-			panic(xerrors.Errorf("unknown symbol=%s", symbol))
+			panic(fmt.Errorf("unknown symbol=%s", symbol))
 		}
 	}
 

--- a/internal/blockchain/restapi/client_test.go
+++ b/internal/blockchain/restapi/client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -13,7 +14,6 @@ import (
 
 	"go.uber.org/fx"
 	"go.uber.org/mock/gomock"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/blockchain/restapi"
 	restapimocks "github.com/coinbase/chainstorage/internal/blockchain/restapi/mocks"
@@ -289,7 +289,7 @@ func TestCall_URLError(t *testing.T) {
 	urlError := &url.Error{
 		Op:  "Post",
 		URL: "foo.com",
-		Err: xerrors.Errorf("a test error"),
+		Err: fmt.Errorf("a test error"),
 	}
 	httpClient.EXPECT().Do(gomock.Any()).Return(nil, urlError).Times(retry.DefaultMaxAttempts)
 

--- a/internal/cadence/test_runtime.go
+++ b/internal/cadence/test_runtime.go
@@ -2,13 +2,14 @@ package cadence
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/workflow"
 	"go.uber.org/zap"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/utils/timesource"
 )
@@ -53,11 +54,11 @@ func (r *testRuntime) RegisterActivity(a any, options activity.RegisterOptions) 
 func (r *testRuntime) ExecuteWorkflow(ctx context.Context, options client.StartWorkflowOptions, workflow any, request any) (client.WorkflowRun, error) {
 	r.env.ExecuteWorkflow(workflow, request)
 	if !r.env.IsWorkflowCompleted() {
-		return nil, xerrors.New("workflow not completed")
+		return nil, errors.New("workflow not completed")
 	}
 
 	if err := r.env.GetWorkflowError(); err != nil {
-		return nil, xerrors.Errorf("workflow failed: %w", err)
+		return nil, fmt.Errorf("workflow failed: %w", err)
 	}
 
 	return testWorkflowRun{}, nil

--- a/internal/cron/job.go
+++ b/internal/cron/job.go
@@ -2,13 +2,13 @@ package cron
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/robfig/cron/v3"
 	"github.com/uber-go/tally/v4"
 	"go.uber.org/zap"
 	"golang.org/x/sync/semaphore"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/config"
 	"github.com/coinbase/chainstorage/internal/utils/instrument"
@@ -36,12 +36,12 @@ var _ cron.Job = (*Job)(nil)
 func NewJob(ctx context.Context, cfg *config.Config, logger *zap.Logger, metrics tally.Scope, task Task) (*Job, error) {
 	parallelism := task.Parallelism()
 	if parallelism <= 0 {
-		return nil, xerrors.Errorf("invalid parallelism: %v", parallelism)
+		return nil, fmt.Errorf("invalid parallelism: %v", parallelism)
 	}
 
 	sem := semaphore.NewWeighted(parallelism)
 	if err := sem.Acquire(ctx, parallelism); err != nil {
-		return nil, xerrors.Errorf("failed to acquire the semaphore: %w", err)
+		return nil, fmt.Errorf("failed to acquire the semaphore: %w", err)
 	}
 
 	taskName := task.Name()

--- a/internal/cron/polling_canary.go
+++ b/internal/cron/polling_canary.go
@@ -2,11 +2,12 @@ package cron
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"time"
 
 	"go.uber.org/fx"
 	"go.uber.org/zap"
-	"golang.org/x/xerrors"
 	"google.golang.org/grpc/codes"
 
 	"github.com/coinbase/chainstorage/internal/config"
@@ -76,11 +77,11 @@ func (t *pollingCanaryTask) Run(ctx context.Context) error {
 	if err != nil {
 		// Skip the task if it is a not-found error.
 		var grpcerr gateway.GrpcError
-		if xerrors.As(err, &grpcerr) && grpcerr.GRPCStatus().Code() == codes.NotFound {
+		if errors.As(err, &grpcerr) && grpcerr.GRPCStatus().Code() == codes.NotFound {
 			return nil
 		}
 
-		return xerrors.Errorf("failed to call GetLatestBlock %w", err)
+		return fmt.Errorf("failed to call GetLatestBlock %w", err)
 	}
 
 	t.logger.Info(
@@ -111,7 +112,7 @@ func (t *pollingCanaryTask) Run(ctx context.Context) error {
 			Height: height,
 			Hash:   hash,
 		}); err != nil {
-			return xerrors.Errorf("failed to call GetBlockFile (height=%v, hash=%v): %w", height, hash, err)
+			return fmt.Errorf("failed to call GetBlockFile (height=%v, hash=%v): %w", height, hash, err)
 		}
 
 		return nil
@@ -123,7 +124,7 @@ func (t *pollingCanaryTask) Run(ctx context.Context) error {
 			StartHeight: startHeight,
 			EndHeight:   endHeight,
 		}); err != nil {
-			return xerrors.Errorf("failed to call GetBlockFilesByRange for blocks [%v, %v): %w", startHeight, endHeight, err)
+			return fmt.Errorf("failed to call GetBlockFilesByRange for blocks [%v, %v): %w", startHeight, endHeight, err)
 		}
 
 		return nil
@@ -135,7 +136,7 @@ func (t *pollingCanaryTask) Run(ctx context.Context) error {
 			Height: height,
 			Hash:   hash,
 		}); err != nil {
-			return xerrors.Errorf("failed to call GetRawBlock (height=%v, hash=%v): %w", height, hash, err)
+			return fmt.Errorf("failed to call GetRawBlock (height=%v, hash=%v): %w", height, hash, err)
 		}
 
 		return nil
@@ -147,7 +148,7 @@ func (t *pollingCanaryTask) Run(ctx context.Context) error {
 			StartHeight: startHeight,
 			EndHeight:   endHeight,
 		}); err != nil {
-			return xerrors.Errorf("failed to call GetRawBlocksByRange for blocks [%v, %v): %w", startHeight, endHeight, err)
+			return fmt.Errorf("failed to call GetRawBlocksByRange for blocks [%v, %v): %w", startHeight, endHeight, err)
 		}
 
 		return nil
@@ -159,7 +160,7 @@ func (t *pollingCanaryTask) Run(ctx context.Context) error {
 			Height: height,
 			Hash:   hash,
 		}); err != nil {
-			return xerrors.Errorf("failed to call GetNativeBlock (height=%v, hash=%v): %w", height, hash, err)
+			return fmt.Errorf("failed to call GetNativeBlock (height=%v, hash=%v): %w", height, hash, err)
 		}
 
 		return nil
@@ -171,7 +172,7 @@ func (t *pollingCanaryTask) Run(ctx context.Context) error {
 			StartHeight: startHeight,
 			EndHeight:   endHeight,
 		}); err != nil {
-			return xerrors.Errorf("failed to call GetNativeBlocksByRange for blocks [%v, %v): %w", startHeight, endHeight, err)
+			return fmt.Errorf("failed to call GetNativeBlocksByRange for blocks [%v, %v): %w", startHeight, endHeight, err)
 		}
 
 		return nil
@@ -184,7 +185,7 @@ func (t *pollingCanaryTask) Run(ctx context.Context) error {
 				Height: height,
 				Hash:   hash,
 			}); err != nil {
-				return xerrors.Errorf("failed to call GetRosettaBlock (height=%v, hash=%v): %w", height, hash, err)
+				return fmt.Errorf("failed to call GetRosettaBlock (height=%v, hash=%v): %w", height, hash, err)
 			}
 
 			return nil
@@ -198,7 +199,7 @@ func (t *pollingCanaryTask) Run(ctx context.Context) error {
 				StartHeight: startHeight,
 				EndHeight:   endHeight,
 			}); err != nil {
-				return xerrors.Errorf("failed to call GetRosettaBlocksByRange for blocks [%v, %v): %w", startHeight, endHeight, err)
+				return fmt.Errorf("failed to call GetRosettaBlocksByRange for blocks [%v, %v): %w", startHeight, endHeight, err)
 			}
 
 			return nil
@@ -206,7 +207,7 @@ func (t *pollingCanaryTask) Run(ctx context.Context) error {
 	}
 
 	if err := group.Wait(); err != nil {
-		return xerrors.Errorf("failed to finish canary task: %w", err)
+		return fmt.Errorf("failed to finish canary task: %w", err)
 	}
 
 	return nil
@@ -214,7 +215,7 @@ func (t *pollingCanaryTask) Run(ctx context.Context) error {
 
 func (t *pollingCanaryTask) filterError(err error) error {
 	var grpcErr gateway.GrpcError
-	if xerrors.As(err, &grpcErr) {
+	if errors.As(err, &grpcErr) {
 		code := grpcErr.GRPCStatus().Code()
 		if code == codes.Unimplemented || code == codes.FailedPrecondition {
 			return nil

--- a/internal/cron/runner.go
+++ b/internal/cron/runner.go
@@ -2,12 +2,12 @@ package cron
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/robfig/cron/v3"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/utils/fxparams"
 	"github.com/coinbase/chainstorage/internal/utils/log"
@@ -66,11 +66,11 @@ func RegisterRunner(params RunnerParams) error {
 
 		job, err := NewJob(jobCtx, params.Config, logger, metrics, task)
 		if err != nil {
-			return xerrors.Errorf("failed to create job %v: %w", taskName, err)
+			return fmt.Errorf("failed to create job %v: %w", taskName, err)
 		}
 
 		if _, err := c.AddJob(task.Spec(), job); err != nil {
-			return xerrors.Errorf("failed to add job %v: %w", taskName, err)
+			return fmt.Errorf("failed to add job %v: %w", taskName, err)
 		}
 	}
 

--- a/internal/cron/workflow_status.go
+++ b/internal/cron/workflow_status.go
@@ -2,13 +2,13 @@ package cron
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"time"
 
 	"github.com/uber-go/tally/v4"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/cadence"
 	"github.com/coinbase/chainstorage/internal/config"
@@ -134,11 +134,11 @@ func (t *workflowStatusTask) Run(ctx context.Context) error {
 
 	// Mark open workflows twice because sometimes the result misses some workflows due to `ContinueAsNew`
 	if err := t.markOpenWorkflows(ctx, expectedWorkflowRunning); err != nil {
-		return xerrors.Errorf("failed to mark open workflows: %w", err)
+		return fmt.Errorf("failed to mark open workflows: %w", err)
 	}
 	time.Sleep(1 * time.Second)
 	if err := t.markOpenWorkflows(ctx, expectedWorkflowRunning); err != nil {
-		return xerrors.Errorf("failed to mark open workflows: %w", err)
+		return fmt.Errorf("failed to mark open workflows: %w", err)
 	}
 
 	for workflowName, isRunning := range expectedWorkflowRunning {
@@ -157,7 +157,7 @@ func (t *workflowStatusTask) Run(ctx context.Context) error {
 func (t *workflowStatusTask) markOpenWorkflows(ctx context.Context, expectedWorkflowMap map[string]bool) error {
 	openWorkflows, err := t.runtime.ListOpenWorkflows(ctx, t.config.Cadence.Domain, maxPageSize)
 	if err != nil {
-		return xerrors.Errorf("failed to get open workflows: %w", err)
+		return fmt.Errorf("failed to get open workflows: %w", err)
 	}
 	for _, wf := range openWorkflows.Executions {
 		openWorkflow := wf.Execution.WorkflowId

--- a/internal/dlq/firestore/dlq.go
+++ b/internal/dlq/firestore/dlq.go
@@ -3,11 +3,11 @@ package firestore
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"cloud.google.com/go/firestore"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/config"
 	"github.com/coinbase/chainstorage/internal/dlq/internal"
@@ -56,12 +56,12 @@ func New(params DLQParams) (DLQ, error) {
 	ctx := context.Background()
 	config := params.Config.GCP
 	if config == nil {
-		return nil, xerrors.Errorf("failed to create firestore meta storage: missing GCP config")
+		return nil, fmt.Errorf("failed to create firestore meta storage: missing GCP config")
 	}
 
 	client, err := firestore.NewClient(ctx, config.Project)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to create firestore client: %w", err)
+		return nil, fmt.Errorf("failed to create firestore client: %w", err)
 	}
 	metrics := params.Metrics.SubScope("dlq").Tagged(map[string]string{
 		"storage_type": "firestore",
@@ -97,7 +97,7 @@ func (q *dlqImpl) SendMessage(ctx context.Context, message *internal.Message) er
 	return q.instrumentSendMessage.Instrument(ctx, func(ctx context.Context) error {
 		body, err := json.Marshal(message.Data)
 		if err != nil {
-			return xerrors.Errorf("failed to marshal body: %w", err)
+			return fmt.Errorf("failed to marshal body: %w", err)
 		}
 		messageBody := string(body)
 
@@ -110,7 +110,7 @@ func (q *dlqImpl) SendMessage(ctx context.Context, message *internal.Message) er
 		})
 
 		if err != nil {
-			return xerrors.Errorf("failed to send message: %w", err)
+			return fmt.Errorf("failed to send message: %w", err)
 		}
 
 		q.logger.Info(

--- a/internal/dlq/internal/dlq.go
+++ b/internal/dlq/internal/dlq.go
@@ -2,10 +2,11 @@ package internal
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"time"
 
 	"go.uber.org/fx"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/config"
 	"github.com/coinbase/chainstorage/internal/utils/fxparams"
@@ -40,7 +41,7 @@ type (
 )
 
 var (
-	ErrNotFound = xerrors.New("not found")
+	ErrNotFound = errors.New("not found")
 )
 
 func WithDLQFactory(params DLQFactoryParams) (DLQ, error) {
@@ -53,15 +54,15 @@ func WithDLQFactory(params DLQFactoryParams) (DLQ, error) {
 		factory = params.Firestore
 	}
 	if factory == nil {
-		return nil, xerrors.Errorf("dlq type is not implemented: %v", dlqType)
+		return nil, fmt.Errorf("dlq type is not implemented: %v", dlqType)
 	}
 	dlq, err := factory.Create()
 	if err != nil {
-		return nil, xerrors.Errorf("failed to create dlq of type %v, error: %w", dlqType, err)
+		return nil, fmt.Errorf("failed to create dlq of type %v, error: %w", dlqType, err)
 	}
 	return dlq, nil
 }
 
 func FilterError(err error) bool {
-	return xerrors.Is(err, ErrNotFound)
+	return errors.Is(err, ErrNotFound)
 }

--- a/internal/dlq/internal/noop.go
+++ b/internal/dlq/internal/noop.go
@@ -2,8 +2,7 @@ package internal
 
 import (
 	"context"
-
-	"golang.org/x/xerrors"
+	"errors"
 )
 
 type nopImpl struct{}
@@ -23,7 +22,7 @@ func (q *nopImpl) ResendMessage(_ context.Context, _ *Message) error {
 }
 
 func (q *nopImpl) ReceiveMessage(_ context.Context) (*Message, error) {
-	return nil, xerrors.New("not implemented")
+	return nil, errors.New("not implemented")
 }
 
 func (q *nopImpl) DeleteMessage(_ context.Context, _ *Message) error {

--- a/internal/dlq/sqs/dlq_local.go
+++ b/internal/dlq/sqs/dlq_local.go
@@ -1,10 +1,12 @@
 package sqs
 
 import (
+	"errors"
+	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/sqs"
 	"go.uber.org/zap"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/utils/pointer"
 )
@@ -14,8 +16,8 @@ func (q *dlqImpl) resetLocalResources() error {
 
 	if err := q.initQueueURL(); err != nil {
 		var aerr awserr.Error
-		if !xerrors.As(err, &aerr) || aerr.Code() != sqs.ErrCodeQueueDoesNotExist {
-			return xerrors.Errorf("failed to init queue url: %w", err)
+		if !errors.As(err, &aerr) || aerr.Code() != sqs.ErrCodeQueueDoesNotExist {
+			return fmt.Errorf("failed to init queue url: %w", err)
 		}
 	}
 
@@ -23,7 +25,7 @@ func (q *dlqImpl) resetLocalResources() error {
 		if _, err := q.client.DeleteQueue(&sqs.DeleteQueueInput{
 			QueueUrl: pointer.Ref(q.queueURL),
 		}); err != nil {
-			return xerrors.Errorf("failed to delete queue: %w", err)
+			return fmt.Errorf("failed to delete queue: %w", err)
 		}
 
 		q.logger.Info("deleted sqs queue")
@@ -35,7 +37,7 @@ func (q *dlqImpl) resetLocalResources() error {
 			QueueName: pointer.Ref(q.config.AWS.DLQ.Name),
 		})
 		if err != nil {
-			return xerrors.Errorf("failed to create queue: %w", err)
+			return fmt.Errorf("failed to create queue: %w", err)
 		}
 
 		q.logger.Info("created sqs queue", zap.Reflect("output", output))

--- a/internal/dlq/sqs/dlq_test.go
+++ b/internal/dlq/sqs/dlq_test.go
@@ -2,10 +2,10 @@ package sqs
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"go.uber.org/fx"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/config"
 	"github.com/coinbase/chainstorage/internal/dlq/internal"
@@ -54,7 +54,7 @@ func TestIntegrationDLQ(t *testing.T) {
 
 	_, err = q.ReceiveMessage(context.Background())
 	require.Error(err)
-	require.True(xerrors.Is(err, internal.ErrNotFound))
+	require.True(errors.Is(err, internal.ErrNotFound))
 }
 
 func TestIntegrationDLQ_Resend(t *testing.T) {
@@ -109,7 +109,7 @@ func TestIntegrationDLQ_Resend(t *testing.T) {
 
 	_, err = q.ReceiveMessage(context.Background())
 	require.Error(err)
-	require.True(xerrors.Is(err, internal.ErrNotFound))
+	require.True(errors.Is(err, internal.ErrNotFound))
 }
 
 func TestIntegrationDLQ_UnknownTopic(t *testing.T) {
@@ -149,5 +149,5 @@ func TestIntegrationDLQ_UnknownTopic(t *testing.T) {
 
 	_, err = q.ReceiveMessage(context.Background())
 	require.Error(err)
-	require.True(xerrors.Is(err, internal.ErrNotFound))
+	require.True(errors.Is(err, internal.ErrNotFound))
 }

--- a/internal/gateway/chainstorage_client.go
+++ b/internal/gateway/chainstorage_client.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -12,7 +13,6 @@ import (
 	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
-	"golang.org/x/xerrors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -138,13 +138,13 @@ func NewChainstorageClient(params Params) (Client, error) {
 
 	conn, err := grpc.DialContext(ctx, address, opts...)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to dial grpc: %w", err)
+		return nil, fmt.Errorf("failed to dial grpc: %w", err)
 	}
 
 	params.Lifecycle.Append(fx.Hook{
 		OnStop: func(ctx context.Context) error {
 			if err := conn.Close(); err != nil {
-				return xerrors.Errorf("failed to close chainstorage connection: %w", err)
+				return fmt.Errorf("failed to close chainstorage connection: %w", err)
 			}
 
 			return nil

--- a/internal/gateway/rest_client.go
+++ b/internal/gateway/rest_client.go
@@ -3,6 +3,8 @@ package gateway
 import (
 	"bytes"
 	"context"
+	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -10,7 +12,6 @@ import (
 
 	"github.com/cenkalti/backoff"
 	"go.uber.org/zap"
-	"golang.org/x/xerrors"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
@@ -43,7 +44,7 @@ const (
 var (
 	_ Client = (*restClient)(nil)
 
-	ErrNotImplemented = xerrors.New("not implemented")
+	ErrNotImplemented = errors.New("not implemented")
 )
 
 func newRestClient(params Params) (Client, error) {
@@ -83,7 +84,7 @@ func newRestClient(params Params) (Client, error) {
 func (c *restClient) GetLatestBlock(ctx context.Context, request *api.GetLatestBlockRequest, _ ...grpc.CallOption) (*api.GetLatestBlockResponse, error) {
 	var response api.GetLatestBlockResponse
 	if err := c.makeRequest(ctx, "GetLatestBlock", request, &response); err != nil {
-		return nil, xerrors.Errorf("failed to make request: %w", err)
+		return nil, fmt.Errorf("failed to make request: %w", err)
 	}
 
 	return &response, nil
@@ -92,7 +93,7 @@ func (c *restClient) GetLatestBlock(ctx context.Context, request *api.GetLatestB
 func (c *restClient) GetBlockFile(ctx context.Context, request *api.GetBlockFileRequest, _ ...grpc.CallOption) (*api.GetBlockFileResponse, error) {
 	var response api.GetBlockFileResponse
 	if err := c.makeRequest(ctx, "GetBlockFile", request, &response); err != nil {
-		return nil, xerrors.Errorf("failed to make request: %w", err)
+		return nil, fmt.Errorf("failed to make request: %w", err)
 	}
 
 	return &response, nil
@@ -101,7 +102,7 @@ func (c *restClient) GetBlockFile(ctx context.Context, request *api.GetBlockFile
 func (c *restClient) GetBlockFilesByRange(ctx context.Context, request *api.GetBlockFilesByRangeRequest, _ ...grpc.CallOption) (*api.GetBlockFilesByRangeResponse, error) {
 	var response api.GetBlockFilesByRangeResponse
 	if err := c.makeRequest(ctx, "GetBlockFilesByRange", request, &response); err != nil {
-		return nil, xerrors.Errorf("failed to make request: %w", err)
+		return nil, fmt.Errorf("failed to make request: %w", err)
 	}
 
 	return &response, nil
@@ -110,7 +111,7 @@ func (c *restClient) GetBlockFilesByRange(ctx context.Context, request *api.GetB
 func (c *restClient) GetRawBlock(ctx context.Context, request *api.GetRawBlockRequest, _ ...grpc.CallOption) (*api.GetRawBlockResponse, error) {
 	var response api.GetRawBlockResponse
 	if err := c.makeRequest(ctx, "GetRawBlock", request, &response); err != nil {
-		return nil, xerrors.Errorf("failed to make request: %w", err)
+		return nil, fmt.Errorf("failed to make request: %w", err)
 	}
 
 	return &response, nil
@@ -119,7 +120,7 @@ func (c *restClient) GetRawBlock(ctx context.Context, request *api.GetRawBlockRe
 func (c *restClient) GetRawBlocksByRange(ctx context.Context, request *api.GetRawBlocksByRangeRequest, _ ...grpc.CallOption) (*api.GetRawBlocksByRangeResponse, error) {
 	var response api.GetRawBlocksByRangeResponse
 	if err := c.makeRequest(ctx, "GetRawBlocksByRange", request, &response); err != nil {
-		return nil, xerrors.Errorf("failed to make request: %w", err)
+		return nil, fmt.Errorf("failed to make request: %w", err)
 	}
 
 	return &response, nil
@@ -128,7 +129,7 @@ func (c *restClient) GetRawBlocksByRange(ctx context.Context, request *api.GetRa
 func (c *restClient) GetNativeBlock(ctx context.Context, request *api.GetNativeBlockRequest, _ ...grpc.CallOption) (*api.GetNativeBlockResponse, error) {
 	var response api.GetNativeBlockResponse
 	if err := c.makeRequest(ctx, "GetNativeBlock", request, &response); err != nil {
-		return nil, xerrors.Errorf("failed to make request: %w", err)
+		return nil, fmt.Errorf("failed to make request: %w", err)
 	}
 
 	return &response, nil
@@ -137,7 +138,7 @@ func (c *restClient) GetNativeBlock(ctx context.Context, request *api.GetNativeB
 func (c *restClient) GetNativeBlocksByRange(ctx context.Context, request *api.GetNativeBlocksByRangeRequest, _ ...grpc.CallOption) (*api.GetNativeBlocksByRangeResponse, error) {
 	var response api.GetNativeBlocksByRangeResponse
 	if err := c.makeRequest(ctx, "GetNativeBlocksByRange", request, &response); err != nil {
-		return nil, xerrors.Errorf("failed to make request: %w", err)
+		return nil, fmt.Errorf("failed to make request: %w", err)
 	}
 
 	return &response, nil
@@ -146,7 +147,7 @@ func (c *restClient) GetNativeBlocksByRange(ctx context.Context, request *api.Ge
 func (c *restClient) GetRosettaBlock(ctx context.Context, request *api.GetRosettaBlockRequest, _ ...grpc.CallOption) (*api.GetRosettaBlockResponse, error) {
 	var response api.GetRosettaBlockResponse
 	if err := c.makeRequest(ctx, "GetRosettaBlock", request, &response); err != nil {
-		return nil, xerrors.Errorf("failed to make request: %w", err)
+		return nil, fmt.Errorf("failed to make request: %w", err)
 	}
 
 	return &response, nil
@@ -155,20 +156,20 @@ func (c *restClient) GetRosettaBlock(ctx context.Context, request *api.GetRosett
 func (c *restClient) GetRosettaBlocksByRange(ctx context.Context, request *api.GetRosettaBlocksByRangeRequest, _ ...grpc.CallOption) (*api.GetRosettaBlocksByRangeResponse, error) {
 	var response api.GetRosettaBlocksByRangeResponse
 	if err := c.makeRequest(ctx, "GetRosettaBlocksByRange", request, &response); err != nil {
-		return nil, xerrors.Errorf("failed to make request: %w", err)
+		return nil, fmt.Errorf("failed to make request: %w", err)
 	}
 
 	return &response, nil
 }
 
 func (c *restClient) StreamChainEvents(ctx context.Context, request *api.ChainEventsRequest, _ ...grpc.CallOption) (api.ChainStorage_StreamChainEventsClient, error) {
-	return nil, xerrors.Errorf("streaming is not supported under restful mode: %w", ErrNotImplemented)
+	return nil, fmt.Errorf("streaming is not supported under restful mode: %w", ErrNotImplemented)
 }
 
 func (c *restClient) GetChainEvents(ctx context.Context, request *api.GetChainEventsRequest, _ ...grpc.CallOption) (*api.GetChainEventsResponse, error) {
 	var response api.GetChainEventsResponse
 	if err := c.makeRequest(ctx, "GetChainEvents", request, &response); err != nil {
-		return nil, xerrors.Errorf("failed to make request: %w", err)
+		return nil, fmt.Errorf("failed to make request: %w", err)
 	}
 
 	return &response, nil
@@ -177,7 +178,7 @@ func (c *restClient) GetChainEvents(ctx context.Context, request *api.GetChainEv
 func (c *restClient) GetChainMetadata(ctx context.Context, request *api.GetChainMetadataRequest, _ ...grpc.CallOption) (*api.GetChainMetadataResponse, error) {
 	var response api.GetChainMetadataResponse
 	if err := c.makeRequest(ctx, "GetChainMetadata", request, &response); err != nil {
-		return nil, xerrors.Errorf("failed to make request: %w", err)
+		return nil, fmt.Errorf("failed to make request: %w", err)
 	}
 
 	return &response, nil
@@ -186,7 +187,7 @@ func (c *restClient) GetChainMetadata(ctx context.Context, request *api.GetChain
 func (c *restClient) GetVersionedChainEvent(ctx context.Context, request *api.GetVersionedChainEventRequest, _ ...grpc.CallOption) (*api.GetVersionedChainEventResponse, error) {
 	var response api.GetVersionedChainEventResponse
 	if err := c.makeRequest(ctx, "GetVersionedChainEvent", request, &response); err != nil {
-		return nil, xerrors.Errorf("failed to make request: %w", err)
+		return nil, fmt.Errorf("failed to make request: %w", err)
 	}
 
 	return &response, nil
@@ -195,7 +196,7 @@ func (c *restClient) GetVersionedChainEvent(ctx context.Context, request *api.Ge
 func (c *restClient) GetBlockByTransaction(ctx context.Context, in *api.GetBlockByTransactionRequest, opts ...grpc.CallOption) (*api.GetBlockByTransactionResponse, error) {
 	var response api.GetBlockByTransactionResponse
 	if err := c.makeRequest(ctx, "GetBlockByTransaction", in, &response); err != nil {
-		return nil, xerrors.Errorf("failed to make request: %w", err)
+		return nil, fmt.Errorf("failed to make request: %w", err)
 	}
 
 	return &response, nil
@@ -204,7 +205,7 @@ func (c *restClient) GetBlockByTransaction(ctx context.Context, in *api.GetBlock
 func (c *restClient) GetNativeTransaction(ctx context.Context, in *api.GetNativeTransactionRequest, opts ...grpc.CallOption) (*api.GetNativeTransactionResponse, error) {
 	var response api.GetNativeTransactionResponse
 	if err := c.makeRequest(ctx, "GetNativeTransaction", in, &response); err != nil {
-		return nil, xerrors.Errorf("failed to make request: %w", err)
+		return nil, fmt.Errorf("failed to make request: %w", err)
 	}
 
 	return &response, nil
@@ -213,7 +214,7 @@ func (c *restClient) GetNativeTransaction(ctx context.Context, in *api.GetNative
 func (c *restClient) GetVerifiedAccountState(ctx context.Context, in *api.GetVerifiedAccountStateRequest, opts ...grpc.CallOption) (*api.GetVerifiedAccountStateResponse, error) {
 	var response api.GetVerifiedAccountStateResponse
 	if err := c.makeRequest(ctx, "GetVerifiedAccountState", in, &response); err != nil {
-		return nil, xerrors.Errorf("failed to make request: %w", err)
+		return nil, fmt.Errorf("failed to make request: %w", err)
 	}
 
 	return &response, nil
@@ -224,13 +225,13 @@ func (c *restClient) makeRequest(ctx context.Context, method string, request pro
 		marshaler := protojson.MarshalOptions{}
 		requestBody, err := marshaler.Marshal(request)
 		if err != nil {
-			return xerrors.Errorf("failed to marshal request: %w", err)
+			return fmt.Errorf("failed to marshal request: %w", err)
 		}
 
 		url := c.getURL(method)
 		httpRequest, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(requestBody))
 		if err != nil {
-			return xerrors.Errorf("failed to create request: %w", err)
+			return fmt.Errorf("failed to create request: %w", err)
 		}
 
 		httpRequest.Header.Set("Content-Type", "application/json")
@@ -246,7 +247,7 @@ func (c *restClient) makeRequest(ctx context.Context, method string, request pro
 		)
 		httpResponse, err := c.httpClient.Do(httpRequest)
 		if err != nil {
-			return retry.Retryable(xerrors.Errorf("failed to send http request: %w", err))
+			return retry.Retryable(fmt.Errorf("failed to send http request: %w", err))
 		}
 
 		finalizer := finalizer.WithCloser(httpResponse.Body)
@@ -254,14 +255,14 @@ func (c *restClient) makeRequest(ctx context.Context, method string, request pro
 
 		body, err := ioutil.ReadAll(httpResponse.Body)
 		if err != nil {
-			return retry.Retryable(xerrors.Errorf("failed to read from http response: %w", err))
+			return retry.Retryable(fmt.Errorf("failed to read from http response: %w", err))
 		}
 		if statusCode := httpResponse.StatusCode; statusCode != http.StatusOK {
 			if statusCode == 429 || statusCode >= 500 {
-				return retry.Retryable(xerrors.Errorf("received retryable status code %v: %v", statusCode, string(body)))
+				return retry.Retryable(fmt.Errorf("received retryable status code %v: %v", statusCode, string(body)))
 			}
 
-			return xerrors.Errorf("received non-retryable status code %v: %v", statusCode, string(body))
+			return fmt.Errorf("received non-retryable status code %v: %v", statusCode, string(body))
 		}
 
 		unmarshaler := protojson.UnmarshalOptions{
@@ -270,7 +271,7 @@ func (c *restClient) makeRequest(ctx context.Context, method string, request pro
 
 		proto.Reset(response)
 		if err := unmarshaler.Unmarshal(body, response); err != nil {
-			return retry.Retryable(xerrors.Errorf("failed to decode response: %w", err))
+			return retry.Retryable(fmt.Errorf("failed to decode response: %w", err))
 		}
 
 		return nil

--- a/internal/s3/client.go
+++ b/internal/s3/client.go
@@ -1,6 +1,8 @@
 package s3
 
 import (
+	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
@@ -8,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3/s3manager/s3manageriface"
 	otaws "github.com/opentracing-contrib/go-aws-sdk"
 	"go.uber.org/fx"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/utils/fxparams"
 )
@@ -37,7 +38,7 @@ type (
 func NewS3(params S3Params) (*S3, error) {
 	if params.Config.AWS.IsLocalStack {
 		if err := resetLocalResources(params); err != nil {
-			return nil, xerrors.Errorf("failed to prepare local resources for aws s3 session: %w", err)
+			return nil, fmt.Errorf("failed to prepare local resources for aws s3 session: %w", err)
 		}
 	}
 

--- a/internal/s3/client_local.go
+++ b/internal/s3/client_local.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"go.uber.org/zap"
-	"golang.org/x/xerrors"
 )
 
 func resetLocalResources(params S3Params) error {
@@ -41,7 +40,7 @@ func deleteBucketIfExists(log *zap.Logger, bucket string, s3Client s3iface.S3API
 				return nil
 			}
 		}
-		return xerrors.Errorf("failed to get bucket %s: %w", bucket, err)
+		return fmt.Errorf("failed to get bucket %s: %w", bucket, err)
 	}
 
 	log.Info(fmt.Sprintf("bucket %s exists, deleting files...", bucket))
@@ -50,7 +49,7 @@ func deleteBucketIfExists(log *zap.Logger, bucket string, s3Client s3iface.S3API
 	})
 
 	if err := s3manager.NewBatchDeleteWithClient(s3Client).Delete(aws.BackgroundContext(), iter); err != nil {
-		return xerrors.Errorf("failed to delete object under bucket %s: %w", bucket, err)
+		return fmt.Errorf("failed to delete object under bucket %s: %w", bucket, err)
 	}
 
 	log.Info(fmt.Sprintf("deleting bucket %s...", bucket))
@@ -59,7 +58,7 @@ func deleteBucketIfExists(log *zap.Logger, bucket string, s3Client s3iface.S3API
 	}
 	_, err = s3Client.DeleteBucket(deleteInput)
 	if err != nil {
-		return xerrors.Errorf("failed to delete bucket %s: %w", bucket, err)
+		return fmt.Errorf("failed to delete bucket %s: %w", bucket, err)
 	}
 	return nil
 }
@@ -76,7 +75,7 @@ func createBucketIfNotExists(bucket string, s3Client s3iface.S3API) error {
 			}
 		}
 
-		return xerrors.Errorf("failed to create bucket %s: %w", bucket, err)
+		return fmt.Errorf("failed to create bucket %s: %w", bucket, err)
 	}
 
 	return nil

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/fx"
 	"go.uber.org/mock/gomock"
-	"golang.org/x/xerrors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -1698,7 +1697,7 @@ func (s *handlerTestSuite) TestStreamChainEventsErrorOnGetMaxEventId() {
 		events: make([]*api.BlockchainEvent, 0),
 		ctx:    context.Background(),
 	}
-	s.metaStorage.EXPECT().GetMaxEventId(gomock.Any(), s.eventTagForTestEvents).Times(1).Return(int64(0), xerrors.New("blah"))
+	s.metaStorage.EXPECT().GetMaxEventId(gomock.Any(), s.eventTagForTestEvents).Times(1).Return(int64(0), errors.New("blah"))
 	err := s.server.StreamChainEvents(&api.ChainEventsRequest{
 		InitialPositionInStream: InitialPositionLatest,
 	}, mockServer)
@@ -1730,7 +1729,7 @@ func (s *handlerTestSuite) TestStreamChainEventsErrorOnGetFirstEventIdByBlockHei
 		events: make([]*api.BlockchainEvent, 0),
 		ctx:    context.Background(),
 	}
-	s.metaStorage.EXPECT().GetFirstEventIdByBlockHeight(gomock.Any(), s.eventTagForTestEvents, startHeight).Return(int64(0), xerrors.New("blah"))
+	s.metaStorage.EXPECT().GetFirstEventIdByBlockHeight(gomock.Any(), s.eventTagForTestEvents, startHeight).Return(int64(0), errors.New("blah"))
 	err := s.server.StreamChainEvents(&api.ChainEventsRequest{
 		InitialPositionInStream: strconv.FormatUint(startHeight, 10),
 	}, mockServer)
@@ -2122,7 +2121,7 @@ func (s *handlerTestSuite) TestGetChainEventsWithPositionLatest() {
 func (s *handlerTestSuite) TestGetChainEventsWithPositionLatestError() {
 	require := testutil.Require(s.T())
 	maxNumEvents := int64(s.config.Api.StreamingBatchSize) // this is required to use setupMetaStorageForEvents
-	SampleErr := xerrors.New("test error")
+	SampleErr := errors.New("test error")
 	s.metaStorage.EXPECT().GetMaxEventId(gomock.Any(), s.eventTagForTestEvents).Times(1).Return(int64(0), SampleErr)
 
 	resp, err := s.server.GetChainEvents(context.Background(), &api.GetChainEventsRequest{
@@ -2131,7 +2130,7 @@ func (s *handlerTestSuite) TestGetChainEventsWithPositionLatestError() {
 	})
 	require.Error(err)
 	require.Nil(resp)
-	require.True(xerrors.Is(err, SampleErr))
+	require.True(errors.Is(err, SampleErr))
 }
 
 func (s *handlerTestSuite) TestGetChainEventsNotEnoughEvents() {
@@ -2577,7 +2576,7 @@ func (s *handlerTestSuite) TestGetBlockByTransaction_TxNotFound() {
 	transactionHash := "foo"
 
 	s.transactionStorage.EXPECT().GetTransaction(gomock.Any(), stableTag, transactionHash).Times(1).
-		Return(nil, xerrors.New("failed to get transaction"))
+		Return(nil, errors.New("failed to get transaction"))
 
 	resp, err := s.server.GetBlockByTransaction(context.Background(), &api.GetBlockByTransactionRequest{
 		TransactionHash: transactionHash,
@@ -2605,7 +2604,7 @@ func (s *handlerTestSuite) TestGetBlockByTransaction_ErrGetBlockByHeight() {
 		DoAndReturn(func(ctx context.Context, tag uint32, heights []uint64) ([]*api.BlockMetadata, error) {
 			require.Len(heights, 1)
 			require.Equal([]uint64{100}, heights)
-			return nil, xerrors.New("failed to get blockMetadata")
+			return nil, errors.New("failed to get blockMetadata")
 		})
 
 	resp, err := s.server.GetBlockByTransaction(context.Background(), &api.GetBlockByTransactionRequest{

--- a/internal/storage/blobstorage/downloader/block_test.go
+++ b/internal/storage/blobstorage/downloader/block_test.go
@@ -2,6 +2,7 @@ package downloader
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -9,11 +10,10 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/fx"
-	"golang.org/x/xerrors"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
 
-	"github.com/coinbase/chainstorage/internal/storage/internal/errors"
+	storage_errors "github.com/coinbase/chainstorage/internal/storage/internal/errors"
 	storage_utils "github.com/coinbase/chainstorage/internal/storage/utils"
 	"github.com/coinbase/chainstorage/internal/utils/testapp"
 	"github.com/coinbase/chainstorage/internal/utils/testutil"
@@ -95,7 +95,7 @@ func (s *blockDownloaderTestSuite) TestDownloadFailure() {
 	)
 
 	_, err := s.downloader.Download(context.Background(), s.blockFile)
-	require.True(xerrors.Is(err, errors.ErrDownloadFailure))
+	require.True(errors.Is(err, storage_errors.ErrDownloadFailure))
 }
 
 func (s *blockDownloaderTestSuite) TestUnmarshalFailure() {

--- a/internal/storage/blobstorage/internal/blobstorage.go
+++ b/internal/storage/blobstorage/internal/blobstorage.go
@@ -2,9 +2,9 @@ package internal
 
 import (
 	"context"
+	"fmt"
 
 	"go.uber.org/fx"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/config"
 	"github.com/coinbase/chainstorage/internal/utils/fxparams"
@@ -51,11 +51,11 @@ func WithBlobStorageFactory(params BlobStorageFactoryParams) (BlobStorage, error
 		factory = params.GCS
 	}
 	if factory == nil {
-		return nil, xerrors.Errorf("blob storage type is not implemented: %v", storageType)
+		return nil, fmt.Errorf("blob storage type is not implemented: %v", storageType)
 	}
 	result, err := factory.Create()
 	if err != nil {
-		return nil, xerrors.Errorf("failed to create blob storage of type %v: %w", storageType, err)
+		return nil, fmt.Errorf("failed to create blob storage of type %v: %w", storageType, err)
 	}
 	return result, nil
 }

--- a/internal/storage/internal/errors/error.go
+++ b/internal/storage/internal/errors/error.go
@@ -1,15 +1,15 @@
 package errors
 
-import "golang.org/x/xerrors"
+import "errors"
 
 var (
-	ErrRequestCanceled   = xerrors.New("request canceled")
-	ErrDownloadFailure   = xerrors.New("download failure")
-	ErrOutOfRange        = xerrors.New("out of range")
-	ErrInvalidHeight     = xerrors.New("height is lower than block start height")
-	ErrInvalidEventId    = xerrors.New("event id is lower than event start id")
-	ErrItemNotFound      = xerrors.New("item not found")
-	ErrNoEventHistory    = xerrors.New("no event history")
-	ErrNoEventAvailable  = xerrors.New("no event available")
-	ErrNoMaxEventIdFound = xerrors.New("no max event id found")
+	ErrRequestCanceled   = errors.New("request canceled")
+	ErrDownloadFailure   = errors.New("download failure")
+	ErrOutOfRange        = errors.New("out of range")
+	ErrInvalidHeight     = errors.New("height is lower than block start height")
+	ErrInvalidEventId    = errors.New("event id is lower than event start id")
+	ErrItemNotFound      = errors.New("item not found")
+	ErrNoEventHistory    = errors.New("no event history")
+	ErrNoEventAvailable  = errors.New("no event available")
+	ErrNoMaxEventIdFound = errors.New("no max event id found")
 )

--- a/internal/storage/metastorage/dynamodb/ddb_table_test.go
+++ b/internal/storage/metastorage/dynamodb/ddb_table_test.go
@@ -2,6 +2,7 @@ package dynamodb
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -10,9 +11,8 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"golang.org/x/xerrors"
 
-	"github.com/coinbase/chainstorage/internal/storage/internal/errors"
+	storage_errors "github.com/coinbase/chainstorage/internal/storage/internal/errors"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
@@ -186,7 +186,7 @@ func (s *DDBTableTestSuite) TestQueryItem_RequestCanceledFailure() {
 	queryResult, err := s.table.QueryItems(context.Background(), &QueryItemsRequest{})
 
 	require.Error(err)
-	require.True(xerrors.Is(err, errors.ErrRequestCanceled))
+	require.True(errors.Is(err, storage_errors.ErrRequestCanceled))
 	require.Nil(queryResult)
 }
 
@@ -213,7 +213,7 @@ func (s *DDBTableTestSuite) TestQueryItem_ItemNotFoundErr() {
 	updateResult, err := s.table.QueryItems(context.Background(), &QueryItemsRequest{})
 
 	require.Error(err)
-	require.ErrorIs(err, errors.ErrItemNotFound)
+	require.ErrorIs(err, storage_errors.ErrItemNotFound)
 	require.Nil(updateResult)
 }
 

--- a/internal/storage/metastorage/dynamodb/event_storage_integration_test.go
+++ b/internal/storage/metastorage/dynamodb/event_storage_integration_test.go
@@ -2,14 +2,14 @@ package dynamodb
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/fx"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/config"
-	"github.com/coinbase/chainstorage/internal/storage/internal/errors"
+	storage_errors "github.com/coinbase/chainstorage/internal/storage/internal/errors"
 	"github.com/coinbase/chainstorage/internal/storage/metastorage/internal"
 	"github.com/coinbase/chainstorage/internal/storage/metastorage/model"
 	"github.com/coinbase/chainstorage/internal/utils/testapp"
@@ -62,7 +62,7 @@ func (s *eventStorageTestSuite) verifyEvents(eventTag uint32, numEvents uint64, 
 	// fetch range with missing item
 	_, err = s.storage.GetEventsByEventIdRange(ctx, eventTag, model.EventIdStartValue, model.EventIdStartValue+int64(numEvents+100))
 	require.Error(err)
-	require.True(xerrors.Is(err, errors.ErrItemNotFound))
+	require.True(errors.Is(err, storage_errors.ErrItemNotFound))
 
 	// fetch valid range
 	fetchedEvents, err := s.storage.GetEventsByEventIdRange(ctx, eventTag, model.EventIdStartValue, model.EventIdStartValue+int64(numEvents))
@@ -130,7 +130,7 @@ func (s *eventStorageTestSuite) TestSetMaxEventId() {
 	require.NoError(err)
 	_, err = s.storage.GetMaxEventId(ctx, s.eventTag)
 	require.Error(err)
-	require.Equal(errors.ErrNoEventHistory, err)
+	require.Equal(storage_errors.ErrNoEventHistory, err)
 }
 
 func (s *eventStorageTestSuite) TestSetMaxEventIdNonDefaultEventTag() {
@@ -166,7 +166,7 @@ func (s *eventStorageTestSuite) TestSetMaxEventIdNonDefaultEventTag() {
 	require.NoError(err)
 	_, err = s.storage.GetMaxEventId(ctx, eventTag)
 	require.Error(err)
-	require.Equal(errors.ErrNoEventHistory, err)
+	require.Equal(storage_errors.ErrNoEventHistory, err)
 }
 
 func (s *eventStorageTestSuite) TestAddEvents() {

--- a/internal/storage/metastorage/dynamodb/meta_storage.go
+++ b/internal/storage/metastorage/dynamodb/meta_storage.go
@@ -1,8 +1,9 @@
 package dynamodb
 
 import (
+	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws/session"
-	"golang.org/x/xerrors"
 
 	"go.uber.org/fx"
 
@@ -31,17 +32,17 @@ type (
 func NewMetaStorage(params Params) (internal.Result, error) {
 	blockStorage, err := newBlockStorage(params)
 	if err != nil {
-		return internal.Result{}, xerrors.Errorf("failed create new BlockStorage: %w", err)
+		return internal.Result{}, fmt.Errorf("failed create new BlockStorage: %w", err)
 	}
 
 	eventStorage, err := newEventStorage(params)
 	if err != nil {
-		return internal.Result{}, xerrors.Errorf("failed create new EventStorage: %w", err)
+		return internal.Result{}, fmt.Errorf("failed create new EventStorage: %w", err)
 	}
 
 	transactionStorage, err := newTransactionStorage(params)
 	if err != nil {
-		return internal.Result{}, xerrors.Errorf("failed create new TransactionStorage: %w", err)
+		return internal.Result{}, fmt.Errorf("failed create new TransactionStorage: %w", err)
 	}
 
 	metaStorage := &metaStorageImpl{

--- a/internal/storage/metastorage/dynamodb/model/transaction.go
+++ b/internal/storage/metastorage/dynamodb/model/transaction.go
@@ -3,8 +3,6 @@ package model
 import (
 	"fmt"
 
-	"golang.org/x/xerrors"
-
 	"github.com/coinbase/chainstorage/internal/storage/metastorage/model"
 )
 
@@ -42,10 +40,10 @@ func MakeTransactionPartitionKey(tag uint32, txnHash string) string {
 
 func TransformToTransaction(entry *TransactionDDBEntry) (*model.Transaction, error) {
 	if entry.Hash == "" {
-		return nil, xerrors.Errorf("transaction hash is empty for returned ddb item(%+v)", entry)
+		return nil, fmt.Errorf("transaction hash is empty for returned ddb item(%+v)", entry)
 	}
 	if entry.BlockHash == "" {
-		return nil, xerrors.Errorf("block hash is empty for returned ddb item(%+v)", entry)
+		return nil, fmt.Errorf("block hash is empty for returned ddb item(%+v)", entry)
 	}
 
 	return &model.Transaction{

--- a/internal/storage/metastorage/firestore/block_storage_integration_test.go
+++ b/internal/storage/metastorage/firestore/block_storage_integration_test.go
@@ -2,6 +2,7 @@ package firestore
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand"
 	"net/http"
@@ -15,13 +16,12 @@ import (
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/fx"
 	"go.uber.org/zap/zaptest"
-	"golang.org/x/xerrors"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
 
 	"github.com/coinbase/chainstorage/internal/blockchain/parser"
 	"github.com/coinbase/chainstorage/internal/config"
-	"github.com/coinbase/chainstorage/internal/storage/internal/errors"
+	storage_errors "github.com/coinbase/chainstorage/internal/storage/internal/errors"
 	"github.com/coinbase/chainstorage/internal/storage/metastorage/internal"
 	"github.com/coinbase/chainstorage/internal/utils/testapp"
 	"github.com/coinbase/chainstorage/internal/utils/testutil"
@@ -99,7 +99,7 @@ func (s *blockStorageTestSuite) TestPersistBlockMetasByInvalidChain() {
 	blocks[73].Hash = "0xdeadbeef"
 	err := s.accessor.PersistBlockMetas(context.Background(), true, blocks, nil)
 	require.Error(err)
-	require.True(xerrors.Is(err, parser.ErrInvalidChain))
+	require.True(errors.Is(err, parser.ErrInvalidChain))
 }
 
 func (s *blockStorageTestSuite) TestPersistBlockMetasByInvalidLastBlock() {
@@ -109,7 +109,7 @@ func (s *blockStorageTestSuite) TestPersistBlockMetasByInvalidLastBlock() {
 	lastBlock.Hash = "0xdeadbeef"
 	err := s.accessor.PersistBlockMetas(context.Background(), true, blocks, lastBlock)
 	require.Error(err)
-	require.True(xerrors.Is(err, parser.ErrInvalidChain))
+	require.True(errors.Is(err, parser.ErrInvalidChain))
 }
 
 func (s *blockStorageTestSuite) TestPersistBlockMetasNotUpdatingWatermark() {
@@ -174,7 +174,7 @@ func (s *blockStorageTestSuite) runTestPersistBlockMetas(totalBlocks int) {
 	// fetch range with missing item
 	_, err = s.accessor.GetBlocksByHeightRange(ctx, tag, startHeight, startHeight+uint64(totalBlocks+100))
 	require.Error(err)
-	require.True(xerrors.Is(err, errors.ErrItemNotFound))
+	require.True(errors.Is(err, storage_errors.ErrItemNotFound))
 
 	// fetch valid range
 	fetchedBlocks, err := s.accessor.GetBlocksByHeightRange(ctx, tag, startHeight, startHeight+uint64(totalBlocks))
@@ -255,7 +255,7 @@ func (s *blockStorageTestSuite) TestPersistBlockMetasNotUpdateWatermark() {
 	}
 
 	_, err = s.accessor.GetLatestBlock(ctx, tag)
-	assert.True(s.T(), xerrors.Is(err, errors.ErrItemNotFound))
+	assert.True(s.T(), errors.Is(err, storage_errors.ErrItemNotFound))
 }
 
 func (s *blockStorageTestSuite) TestPersistBlockMetasNotContinuous() {
@@ -274,35 +274,35 @@ func (s *blockStorageTestSuite) TestPersistBlockMetasDuplicatedHeights() {
 
 func (s *blockStorageTestSuite) TestGetBlocksNotExist() {
 	_, err := s.accessor.GetLatestBlock(context.TODO(), tag)
-	assert.True(s.T(), xerrors.Is(err, errors.ErrItemNotFound))
+	assert.True(s.T(), errors.Is(err, storage_errors.ErrItemNotFound))
 }
 
 func (s *blockStorageTestSuite) TestGetBlockByHeightInvalidHeight() {
 	_, err := s.accessor.GetBlockByHeight(context.TODO(), tag, 0)
-	assert.True(s.T(), xerrors.Is(err, errors.ErrInvalidHeight))
+	assert.True(s.T(), errors.Is(err, storage_errors.ErrInvalidHeight))
 }
 
 func (s *blockStorageTestSuite) TestGetBlocksByHeightsInvalidHeight() {
 	_, err := s.accessor.GetBlocksByHeights(context.TODO(), tag, []uint64{0})
-	assert.True(s.T(), xerrors.Is(err, errors.ErrInvalidHeight))
+	assert.True(s.T(), errors.Is(err, storage_errors.ErrInvalidHeight))
 }
 
 func (s *blockStorageTestSuite) TestGetBlocksByHeightsBlockNotFound() {
 	_, err := s.accessor.GetBlocksByHeights(context.TODO(), tag, []uint64{15})
-	assert.True(s.T(), xerrors.Is(err, errors.ErrItemNotFound))
+	assert.True(s.T(), errors.Is(err, storage_errors.ErrItemNotFound))
 }
 
 func (s *blockStorageTestSuite) TestGetBlockByHashInvalidHeight() {
 	_, err := s.accessor.GetBlockByHash(context.TODO(), tag, 0, "0x0")
-	assert.True(s.T(), xerrors.Is(err, errors.ErrInvalidHeight))
+	assert.True(s.T(), errors.Is(err, storage_errors.ErrInvalidHeight))
 }
 
 func (s *blockStorageTestSuite) TestGetBlocksByHeightRangeInvalidRange() {
 	_, err := s.accessor.GetBlocksByHeightRange(context.TODO(), tag, 100, 100)
-	assert.True(s.T(), xerrors.Is(err, errors.ErrOutOfRange))
+	assert.True(s.T(), errors.Is(err, storage_errors.ErrOutOfRange))
 
 	_, err = s.accessor.GetBlocksByHeightRange(context.TODO(), tag, 0, s.config.Chain.BlockStartHeight)
-	assert.True(s.T(), xerrors.Is(err, errors.ErrInvalidHeight))
+	assert.True(s.T(), errors.Is(err, storage_errors.ErrInvalidHeight))
 }
 
 func (s *blockStorageTestSuite) equalProto(x, y any) {

--- a/internal/storage/metastorage/firestore/event_storage_integration_test.go
+++ b/internal/storage/metastorage/firestore/event_storage_integration_test.go
@@ -2,6 +2,7 @@ package firestore
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -9,10 +10,9 @@ import (
 
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/fx"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/config"
-	"github.com/coinbase/chainstorage/internal/storage/internal/errors"
+	storage_errors "github.com/coinbase/chainstorage/internal/storage/internal/errors"
 	"github.com/coinbase/chainstorage/internal/storage/metastorage/internal"
 	"github.com/coinbase/chainstorage/internal/storage/metastorage/model"
 	"github.com/coinbase/chainstorage/internal/utils/testapp"
@@ -71,7 +71,7 @@ func (s *eventStorageTestSuite) verifyEvents(eventTag uint32, numEvents uint64, 
 	// fetch range with missing item
 	_, err = s.storage.GetEventsByEventIdRange(ctx, eventTag, model.EventIdStartValue, model.EventIdStartValue+int64(numEvents+100))
 	require.Error(err)
-	require.True(xerrors.Is(err, errors.ErrItemNotFound))
+	require.True(errors.Is(err, storage_errors.ErrItemNotFound))
 
 	// fetch valid range
 	fetchedEvents, err := s.storage.GetEventsByEventIdRange(ctx, eventTag, model.EventIdStartValue, model.EventIdStartValue+int64(numEvents))
@@ -135,7 +135,7 @@ func (s *eventStorageTestSuite) TestSetMaxEventId() {
 	require.NoError(err)
 	_, err = s.storage.GetMaxEventId(ctx, s.eventTag)
 	require.Error(err)
-	require.Equal(errors.ErrNoEventHistory, err)
+	require.Equal(storage_errors.ErrNoEventHistory, err)
 }
 
 func (s *eventStorageTestSuite) TestSetMaxEventIdNonDefaultEventTag() {
@@ -171,7 +171,7 @@ func (s *eventStorageTestSuite) TestSetMaxEventIdNonDefaultEventTag() {
 	require.NoError(err)
 	_, err = s.storage.GetMaxEventId(ctx, eventTag)
 	require.Error(err)
-	require.Equal(errors.ErrNoEventHistory, err)
+	require.Equal(storage_errors.ErrNoEventHistory, err)
 }
 
 func (s *eventStorageTestSuite) TestAddEvents() {

--- a/internal/storage/metastorage/firestore/meta_storage.go
+++ b/internal/storage/metastorage/firestore/meta_storage.go
@@ -2,10 +2,10 @@ package firestore
 
 import (
 	"context"
+	"fmt"
 
 	"cloud.google.com/go/firestore"
 	"go.uber.org/fx"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/storage/metastorage/internal"
 	"github.com/coinbase/chainstorage/internal/utils/fxparams"
@@ -32,27 +32,27 @@ func NewMetaStorage(params Params) (internal.Result, error) {
 	ctx := context.Background()
 	config := params.Config.GCP
 	if config == nil {
-		return internal.Result{}, xerrors.Errorf("failed to create firestore meta storage: missing GCP config")
+		return internal.Result{}, fmt.Errorf("failed to create firestore meta storage: missing GCP config")
 	}
 
 	client, err := firestore.NewClient(ctx, config.Project)
 	if err != nil {
-		return internal.Result{}, xerrors.Errorf("failed to create firestore client: %w", err)
+		return internal.Result{}, fmt.Errorf("failed to create firestore client: %w", err)
 	}
 
 	blockStorage, err := newBlockStorage(params, client)
 	if err != nil {
-		return internal.Result{}, xerrors.Errorf("failed create new BlockStorage: %w", err)
+		return internal.Result{}, fmt.Errorf("failed create new BlockStorage: %w", err)
 	}
 
 	eventStorage, err := newEventStorage(params, client)
 	if err != nil {
-		return internal.Result{}, xerrors.Errorf("failed create new EventStorage: %w", err)
+		return internal.Result{}, fmt.Errorf("failed create new EventStorage: %w", err)
 	}
 
 	transactionStorage, err := newTransactionStorage(params, client)
 	if err != nil {
-		return internal.Result{}, xerrors.Errorf("failed create new TransactionStorage: %w", err)
+		return internal.Result{}, fmt.Errorf("failed create new TransactionStorage: %w", err)
 	}
 
 	metaStorage := &metaStorageImpl{

--- a/internal/storage/metastorage/internal/meta_storage.go
+++ b/internal/storage/metastorage/internal/meta_storage.go
@@ -2,9 +2,9 @@ package internal
 
 import (
 	"context"
+	"fmt"
 
 	"go.uber.org/fx"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/config"
 	"github.com/coinbase/chainstorage/internal/storage/metastorage/model"
@@ -85,11 +85,11 @@ func WithMetaStorageFactory(params MetaStorageFactoryParams) (Result, error) {
 		factory = params.Firestore
 	}
 	if factory == nil {
-		return Result{}, xerrors.Errorf("meta storage type is not implemented: %v", storageType)
+		return Result{}, fmt.Errorf("meta storage type is not implemented: %v", storageType)
 	}
 	result, err := factory.Create()
 	if err != nil {
-		return Result{}, xerrors.Errorf("failed to create meta storage of type %v, error: %w", storageType, err)
+		return Result{}, fmt.Errorf("failed to create meta storage of type %v, error: %w", storageType, err)
 	}
 	return result, nil
 }

--- a/internal/storage/utils/utils.go
+++ b/internal/storage/utils/utils.go
@@ -7,8 +7,6 @@ import (
 	"io/ioutil"
 	"strings"
 
-	"golang.org/x/xerrors"
-
 	api "github.com/coinbase/chainstorage/protos/coinbase/chainstorage"
 )
 
@@ -32,16 +30,16 @@ func Compress(data []byte, compression api.Compression) ([]byte, error) {
 		var buf bytes.Buffer
 		zw := gzip.NewWriter(&buf)
 		if _, err := zw.Write(data); err != nil {
-			return nil, xerrors.Errorf("failed to write compressed data: %w", err)
+			return nil, fmt.Errorf("failed to write compressed data: %w", err)
 		}
 		if err := zw.Close(); err != nil {
-			return nil, xerrors.Errorf("failed to close writer: %w", err)
+			return nil, fmt.Errorf("failed to close writer: %w", err)
 		}
 
 		return buf.Bytes(), nil
 	}
 
-	return nil, xerrors.Errorf("failed to compress with unsupported type %v", compression.String())
+	return nil, fmt.Errorf("failed to compress with unsupported type %v", compression.String())
 }
 
 func Decompress(data []byte, compression api.Compression) ([]byte, error) {
@@ -52,19 +50,19 @@ func Decompress(data []byte, compression api.Compression) ([]byte, error) {
 	if compression == api.Compression_GZIP {
 		zr, err := gzip.NewReader(bytes.NewBuffer(data))
 		if err != nil {
-			return nil, xerrors.Errorf("failed to initiate reader: %w", err)
+			return nil, fmt.Errorf("failed to initiate reader: %w", err)
 		}
 		decoded, err := ioutil.ReadAll(zr)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to read data: %w", err)
+			return nil, fmt.Errorf("failed to read data: %w", err)
 		}
 		if err := zr.Close(); err != nil {
-			return nil, xerrors.Errorf("failed to close reader: %w", err)
+			return nil, fmt.Errorf("failed to close reader: %w", err)
 		}
 		return decoded, nil
 	}
 
-	return nil, xerrors.Errorf("failed to decompress with unsupported type %v", compression.String())
+	return nil, fmt.Errorf("failed to decompress with unsupported type %v", compression.String())
 }
 
 func GetObjectKey(key string, compression api.Compression) (string, error) {
@@ -77,5 +75,5 @@ func GetObjectKey(key string, compression api.Compression) (string, error) {
 		return key, nil
 	}
 
-	return "", xerrors.Errorf("failed to get object key with unsupported type %v", compression.String())
+	return "", fmt.Errorf("failed to get object key with unsupported type %v", compression.String())
 }

--- a/internal/utils/fixtures/helper.go
+++ b/internal/utils/fixtures/helper.go
@@ -2,11 +2,11 @@ package fixtures
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path"
 	"runtime"
 
-	"golang.org/x/xerrors"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 
@@ -40,11 +40,11 @@ func WriteFile(relPath string, data []byte) error {
 	defer finalizer.Finalize()
 
 	if _, err := f.Write(data); err != nil {
-		return xerrors.Errorf("failed to write data: %w", err)
+		return fmt.Errorf("failed to write data: %w", err)
 	}
 
 	if _, err := f.WriteString("\n"); err != nil {
-		return xerrors.Errorf("failed to write new line: %w", err)
+		return fmt.Errorf("failed to write new line: %w", err)
 	}
 
 	return finalizer.Close()
@@ -53,11 +53,11 @@ func WriteFile(relPath string, data []byte) error {
 func UnmarshalJSON(pathToFile string, out any) error {
 	data, err := ReadFile(pathToFile)
 	if err != nil {
-		return xerrors.Errorf("failed to read file %v: %w", pathToFile, err)
+		return fmt.Errorf("failed to read file %v: %w", pathToFile, err)
 	}
 
 	if err := json.Unmarshal(data, out); err != nil {
-		return xerrors.Errorf("failed to unmarshal file %v: %w", pathToFile, err)
+		return fmt.Errorf("failed to unmarshal file %v: %w", pathToFile, err)
 	}
 
 	return nil
@@ -72,11 +72,11 @@ func MustUnmarshalJSON(pathToFile string, out any) {
 func MarshalJSON(pathToFile string, in any) error {
 	data, err := json.MarshalIndent(in, "", "  ")
 	if err != nil {
-		return xerrors.Errorf("failed to marshal input: %w", err)
+		return fmt.Errorf("failed to marshal input: %w", err)
 	}
 
 	if err := WriteFile(pathToFile, data); err != nil {
-		return xerrors.Errorf("failed to write to file: %w", err)
+		return fmt.Errorf("failed to write to file: %w", err)
 	}
 
 	return nil
@@ -91,11 +91,11 @@ func MustMarshalJSON(pathToFile string, in any) {
 func UnmarshalPB(pathToFile string, out proto.Message) error {
 	data, err := ReadFile(pathToFile)
 	if err != nil {
-		return xerrors.Errorf("failed to read file %v: %w", pathToFile, err)
+		return fmt.Errorf("failed to read file %v: %w", pathToFile, err)
 	}
 
 	if err := protojson.Unmarshal(data, out); err != nil {
-		return xerrors.Errorf("failed to unmarshal file %v: %w", pathToFile, err)
+		return fmt.Errorf("failed to unmarshal file %v: %w", pathToFile, err)
 	}
 
 	return nil
@@ -113,11 +113,11 @@ func MarshalPB(pathToFile string, in proto.Message) error {
 	var buf []byte
 	var err error
 	if buf, err = marshaler.Marshal(in); err != nil {
-		return xerrors.Errorf("failed to marshal input: %w", err)
+		return fmt.Errorf("failed to marshal input: %w", err)
 	}
 
 	if err := WriteFile(pathToFile, buf); err != nil {
-		return xerrors.Errorf("failed to write to file: %w", err)
+		return fmt.Errorf("failed to write to file: %w", err)
 	}
 
 	return nil

--- a/internal/utils/instrument/instrument_test.go
+++ b/internal/utils/instrument/instrument_test.go
@@ -2,11 +2,11 @@ package instrument
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/uber-go/tally/v4"
 	"go.uber.org/zap/zaptest"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/utils/retry"
 	"github.com/coinbase/chainstorage/internal/utils/testutil"
@@ -36,14 +36,14 @@ func TestInstrument(t *testing.T) {
 			hasError:     true,
 			successValue: 0,
 			errorValue:   1,
-			fn:           func(ctx context.Context) error { return xerrors.New("mock") },
+			fn:           func(ctx context.Context) error { return errors.New("mock") },
 		},
 		{
 			name:         "withRetry",
 			hasError:     true,
 			successValue: 0,
 			errorValue:   1,
-			fn:           func(ctx context.Context) error { return retry.Retryable(xerrors.New("mock")) },
+			fn:           func(ctx context.Context) error { return retry.Retryable(errors.New("mock")) },
 			retry:        retry.New(retry.WithMaxAttempts(2)),
 		},
 		{
@@ -55,7 +55,7 @@ func TestInstrument(t *testing.T) {
 			opts: []Option{
 				WithFilter(func(err error) bool {
 					var target *MockError
-					return xerrors.As(err, &target)
+					return errors.As(err, &target)
 				}),
 			},
 		},
@@ -76,7 +76,7 @@ func TestInstrument(t *testing.T) {
 			hasError:     true,
 			successValue: 0,
 			errorValue:   1,
-			fn:           func(ctx context.Context) error { return xerrors.New("mock") },
+			fn:           func(ctx context.Context) error { return errors.New("mock") },
 			opts: []Option{
 				WithLogger(zaptest.NewLogger(t), "instrument.test"),
 			},
@@ -155,7 +155,7 @@ func TestInstrumentWithRetry(t *testing.T) {
 	operation := func(ctx context.Context) error {
 		numCalls += 1
 		if numCalls < maxAttempts {
-			return retry.Retryable(xerrors.New("mock"))
+			return retry.Retryable(errors.New("mock"))
 		}
 		return nil
 	}
@@ -208,14 +208,14 @@ func TestInstrumentWithResult(t *testing.T) {
 			hasError:     true,
 			successValue: 0,
 			errorValue:   1,
-			fn:           func(ctx context.Context) (string, error) { return statusError, xerrors.New("mock") },
+			fn:           func(ctx context.Context) (string, error) { return statusError, errors.New("mock") },
 		},
 		{
 			name:         "withRetry",
 			hasError:     true,
 			successValue: 0,
 			errorValue:   1,
-			fn:           func(ctx context.Context) (string, error) { return statusError, retry.Retryable(xerrors.New("mock")) },
+			fn:           func(ctx context.Context) (string, error) { return statusError, retry.Retryable(errors.New("mock")) },
 			retry:        retry.NewWithResult[string](retry.WithMaxAttempts(2)),
 		},
 		{
@@ -227,7 +227,7 @@ func TestInstrumentWithResult(t *testing.T) {
 			opts: []Option{
 				WithFilter(func(err error) bool {
 					var target *MockError
-					return xerrors.As(err, &target)
+					return errors.As(err, &target)
 				}),
 			},
 		},
@@ -248,7 +248,7 @@ func TestInstrumentWithResult(t *testing.T) {
 			hasError:     true,
 			successValue: 0,
 			errorValue:   1,
-			fn:           func(ctx context.Context) (string, error) { return statusError, xerrors.New("mock") },
+			fn:           func(ctx context.Context) (string, error) { return statusError, errors.New("mock") },
 			opts: []Option{
 				WithLogger(zaptest.NewLogger(t), "instrument.test"),
 			},

--- a/internal/utils/retry/errors.go
+++ b/internal/utils/retry/errors.go
@@ -3,7 +3,7 @@ package retry
 import (
 	"fmt"
 
-	"golang.org/x/xerrors"
+	"github.com/cockroachdb/errors"
 )
 
 type (
@@ -17,8 +17,8 @@ type (
 )
 
 var (
-	_ xerrors.Wrapper = (*RetryableError)(nil)
-	_ xerrors.Wrapper = (*RateLimitError)(nil)
+	_ errors.Wrapper = (*RetryableError)(nil)
+	_ errors.Wrapper = (*RateLimitError)(nil)
 )
 
 // Retryable returns an error that indicates that the operation should be retried.
@@ -33,7 +33,7 @@ func (e *RetryableError) Error() string {
 }
 
 func (e *RetryableError) Unwrap() error {
-	// Implement `xerrors.Wrapper` so that the original error can be unwrapped.
+	// Implement `errors.Wrapper` so that the original error can be unwrapped.
 	return e.Err
 }
 
@@ -48,6 +48,6 @@ func (e *RateLimitError) Error() string {
 }
 
 func (e *RateLimitError) Unwrap() error {
-	// Implement `xerrors.Wrapper` so that the original error can be unwrapped.
+	// Implement `errors.Wrapper` so that the original error can be unwrapped.
 	return e.Err
 }

--- a/internal/utils/retry/retry_test.go
+++ b/internal/utils/retry/retry_test.go
@@ -2,16 +2,17 @@ package retry
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/cenkalti/backoff/v4"
 	"go.uber.org/zap"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/utils/testutil"
 )
 
-var errMock = xerrors.New("mock error")
+var errMock = errors.New("mock error")
 
 func TestRetry_Success(t *testing.T) {
 	require := testutil.Require(t)
@@ -50,7 +51,7 @@ func TestRetry_NonRetryable(t *testing.T) {
 	err := r.Retry(context.Background(), func(ctx context.Context) error {
 		numCalls += 1
 		if numCalls < 4 {
-			return xerrors.New("mock")
+			return errors.New("mock")
 		}
 
 		return nil
@@ -101,7 +102,7 @@ func TestRetry_RetryableWrapped(t *testing.T) {
 	err := r.Retry(context.Background(), func(ctx context.Context) error {
 		numCalls += 1
 		if numCalls < DefaultMaxAttempts {
-			return xerrors.Errorf("wrapped error: %w", Retryable(errMock))
+			return fmt.Errorf("wrapped error: %w", Retryable(errMock))
 		}
 
 		return nil
@@ -125,7 +126,7 @@ func TestRetry_Permanent(t *testing.T) {
 	})
 	require.Error(err)
 	require.Equal(DefaultMaxAttempts, numCalls)
-	require.True(xerrors.Is(err, errMock))
+	require.True(errors.Is(err, errMock))
 }
 
 func TestRetry_MaxAttemptsExceeded(t *testing.T) {
@@ -143,7 +144,7 @@ func TestRetry_MaxAttemptsExceeded(t *testing.T) {
 	})
 	require.Error(err)
 	require.Equal(DefaultMaxAttempts, numCalls)
-	require.True(xerrors.Is(err, errMock))
+	require.True(errors.Is(err, errMock))
 }
 
 func TestRetry_WithOptions(t *testing.T) {
@@ -165,7 +166,7 @@ func TestRetry_WithOptions(t *testing.T) {
 	})
 	require.Error(err)
 	require.Equal(5, numCalls)
-	require.True(xerrors.Is(err, errMock))
+	require.True(errors.Is(err, errMock))
 }
 
 func TestRetryWithResult(t *testing.T) {
@@ -207,7 +208,7 @@ func TestRetryWithResult_NonRetryable(t *testing.T) {
 	res, err := r.Retry(context.Background(), func(ctx context.Context) (string, error) {
 		numCalls += 1
 		if numCalls < 4 {
-			return "failure", xerrors.New("mock")
+			return "failure", errors.New("mock")
 		}
 
 		return "success", nil

--- a/internal/utils/syncgroup/syncgroup_test.go
+++ b/internal/utils/syncgroup/syncgroup_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"golang.org/x/sync/semaphore"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/utils/testutil"
 )
@@ -136,9 +135,9 @@ func TestSyncGroup_WithFilter(t *testing.T) {
 
 	require := testutil.Require(t)
 
-	errIgnored := xerrors.New("ignore this error")
+	errIgnored := errors.New("ignore this error")
 	group, _ := New(context.Background(), WithFilter(func(err error) error {
-		if xerrors.Is(err, errIgnored) {
+		if errors.Is(err, errIgnored) {
 			return nil
 		}
 
@@ -165,12 +164,12 @@ func TestSyncGroup_WithThrottlingAndFilter(t *testing.T) {
 
 	require := testutil.Require(t)
 
-	errIgnored := xerrors.New("ignore this error")
+	errIgnored := errors.New("ignore this error")
 	group, _ := New(
 		context.Background(),
 		WithThrottling(limit),
 		WithFilter(func(err error) error {
-			if xerrors.Is(err, errIgnored) {
+			if errors.Is(err, errIgnored) {
 				return nil
 			}
 

--- a/internal/utils/testutil/parser_test_utils.go
+++ b/internal/utils/testutil/parser_test_utils.go
@@ -8,7 +8,6 @@ import (
 	rt "github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/xerrors"
 	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/coinbase/chainstorage/internal/utils/fixtures"
@@ -47,7 +46,7 @@ func LoadRosettaRaw(
 	network common.Network) (*api.Block, error) {
 	header, err := json.Marshal(block)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to marshal test rosetta block: %w", err)
+		return nil, fmt.Errorf("failed to marshal test rosetta block: %w", err)
 	}
 
 	rosettaRaw := &api.Block{
@@ -69,7 +68,7 @@ func LoadRosettaRaw(
 	if transactions != nil {
 		txData, err := json.Marshal(transactions)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to marshal test rosetta transaction: %w", err)
+			return nil, fmt.Errorf("failed to marshal test rosetta transaction: %w", err)
 		}
 		rosettaRaw.GetRosetta().OtherTransactions = [][]byte{txData}
 	}

--- a/internal/utils/utils/utils.go
+++ b/internal/utils/utils/utils.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/xerrors"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/coinbase/chainstorage/protos/coinbase/c3/common"
@@ -22,7 +21,7 @@ func ParseCompression(compression string) (api.Compression, error) {
 	compression = strings.ToUpper(compression)
 	parsedCompression, ok := api.Compression_value[compression]
 	if !ok {
-		return api.Compression_NONE, xerrors.Errorf("failed to parse compression type %v", compression)
+		return api.Compression_NONE, fmt.Errorf("failed to parse compression type %v", compression)
 	}
 	return api.Compression(parsedCompression), nil
 }
@@ -65,7 +64,7 @@ func ParseBlockchain(blockchainName string) (common.Blockchain, error) {
 	parsedBlockchain, ok := common.Blockchain_value[formattedBlockchainName]
 	if !ok {
 		return common.Blockchain_BLOCKCHAIN_UNKNOWN,
-			xerrors.Errorf("error blockchain name: `%s` did not parse correctly to an enum", blockchainName)
+			fmt.Errorf("error blockchain name: `%s` did not parse correctly to an enum", blockchainName)
 	}
 
 	return common.Blockchain(parsedBlockchain), nil
@@ -81,7 +80,7 @@ func ParseNetwork(networkName string) (common.Network, error) {
 	parsedNetwork, ok := common.Network_value[formattedNetworkName]
 	if !ok {
 		return common.Network_NETWORK_UNKNOWN,
-			xerrors.Errorf("error network name: `%s` did not parse correctly to an enum", networkName)
+			fmt.Errorf("error network name: `%s` did not parse correctly to an enum", networkName)
 	}
 
 	return common.Network(parsedNetwork), nil

--- a/internal/workflow/activity/activity.go
+++ b/internal/workflow/activity/activity.go
@@ -2,12 +2,13 @@ package activity
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"github.com/go-playground/validator/v10"
 	"go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/workflow"
 	"go.uber.org/zap"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/cadence"
 	"github.com/coinbase/chainstorage/internal/utils/log"
@@ -82,7 +83,7 @@ func (a *baseActivity) executeActivity(ctx workflow.Context, request any, respon
 		}
 
 		if err := a.runtime.ExecuteActivity(ctx, a.name, request, response); err != nil {
-			return xerrors.Errorf("failed to execute activity (name=%v): %w", a.name, err)
+			return fmt.Errorf("failed to execute activity (name=%v): %w", a.name, err)
 		}
 
 		return nil
@@ -91,7 +92,7 @@ func (a *baseActivity) executeActivity(ctx workflow.Context, request any, respon
 
 func (a *baseActivity) validateRequest(request any) error {
 	if err := a.validate.Struct(request); err != nil {
-		return xerrors.Errorf("invalid activity request (name=%v, request=%+v): %w", a.name, request, err)
+		return fmt.Errorf("invalid activity request (name=%v, request=%+v): %w", a.name, request, err)
 	}
 
 	return nil
@@ -111,5 +112,5 @@ func (a *baseActivity) getLogger(ctx context.Context) *zap.Logger {
 }
 
 func IsCanceledError(err error) bool {
-	return xerrors.Is(err, workflow.ErrCanceled)
+	return errors.Is(err, workflow.ErrCanceled)
 }

--- a/internal/workflow/activity/event_loader.go
+++ b/internal/workflow/activity/event_loader.go
@@ -2,11 +2,11 @@ package activity
 
 import (
 	"context"
+	"fmt"
 
 	"go.temporal.io/sdk/workflow"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/cadence"
 	"github.com/coinbase/chainstorage/internal/storage/metastorage"
@@ -57,7 +57,7 @@ func (a *EventLoader) execute(ctx context.Context, request *EventLoaderRequest) 
 	logger := a.getLogger(ctx)
 
 	if err := a.metaStorage.AddEventEntries(ctx, request.EventTag, request.Events); err != nil {
-		return nil, xerrors.Errorf("failed to add events to metaStorage: %w", err)
+		return nil, fmt.Errorf("failed to add events to metaStorage: %w", err)
 	}
 
 	logger.Info(

--- a/internal/workflow/activity/event_loader_test.go
+++ b/internal/workflow/activity/event_loader_test.go
@@ -1,13 +1,13 @@
 package activity
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
 	"go.temporal.io/sdk/testsuite"
 	"go.uber.org/fx"
 	"go.uber.org/mock/gomock"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/cadence"
 	"github.com/coinbase/chainstorage/internal/dlq"
@@ -78,7 +78,7 @@ func (s *EventLoaderTestSuite) TestEventLoader_Error() {
 
 	eventTag := uint32(1)
 	var events []*model.EventEntry
-	s.metaStorage.EXPECT().AddEventEntries(gomock.Any(), eventTag, gomock.Any()).Return(xerrors.Errorf("error loading events"))
+	s.metaStorage.EXPECT().AddEventEntries(gomock.Any(), eventTag, gomock.Any()).Return(fmt.Errorf("error loading events"))
 	request := &EventLoaderRequest{
 		EventTag: eventTag,
 		Events:   events,

--- a/internal/workflow/activity/event_reader.go
+++ b/internal/workflow/activity/event_reader.go
@@ -2,10 +2,11 @@ package activity
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"go.temporal.io/sdk/workflow"
 	"go.uber.org/fx"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/cadence"
 	"github.com/coinbase/chainstorage/internal/storage"
@@ -60,12 +61,12 @@ func (a *EventReader) execute(ctx context.Context, request *EventReaderRequest) 
 
 	eventData, err := a.metaStorage.GetEventsByEventIdRange(ctx, request.EventTag, int64(request.StartSequence), int64(request.EndSequence))
 	if err != nil {
-		if xerrors.Is(err, storage.ErrItemNotFound) {
+		if errors.Is(err, storage.ErrItemNotFound) {
 			// Convert not-found error into an empty response.
 			return &EventReaderResponse{}, nil
 		}
 
-		return nil, xerrors.Errorf("failed to read event from meta storage: %w", err)
+		return nil, fmt.Errorf("failed to read event from meta storage: %w", err)
 	}
 
 	return &EventReaderResponse{

--- a/internal/workflow/activity/event_reconciler.go
+++ b/internal/workflow/activity/event_reconciler.go
@@ -2,10 +2,10 @@ package activity
 
 import (
 	"context"
+	"fmt"
 
 	"go.temporal.io/sdk/workflow"
 	"go.uber.org/fx"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/cadence"
 	"github.com/coinbase/chainstorage/internal/storage/metastorage"
@@ -89,7 +89,7 @@ func (a *EventReconciler) execute(ctx context.Context, request *EventReconcilerR
 func (a *EventReconciler) readBlock(ctx context.Context, tag uint32, height uint64) (*api.BlockMetadata, error) {
 	blockMetadata, err := a.metaStorage.GetBlockByHeight(ctx, tag, height)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to get block(tag=%v) by height=%v: %w", tag, height, err)
+		return nil, fmt.Errorf("failed to get block(tag=%v) by height=%v: %w", tag, height, err)
 	}
 
 	return blockMetadata, nil

--- a/internal/workflow/activity/liveness_check.go
+++ b/internal/workflow/activity/liveness_check.go
@@ -2,12 +2,12 @@ package activity
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"go.temporal.io/sdk/workflow"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/blockchain/client"
 	"github.com/coinbase/chainstorage/internal/blockchain/endpoints"
@@ -67,14 +67,14 @@ func (a *LivenessCheck) execute(ctx context.Context, request *LivenessCheckReque
 	if request.Failover {
 		failoverCtx, err := a.failoverManager.WithFailoverContext(ctx, endpoints.MasterCluster)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to create failover context for master client: %w", err)
+			return nil, fmt.Errorf("failed to create failover context for master client: %w", err)
 		}
 		ctx = failoverCtx
 	}
 
 	violation, err := a.checkLiveness(ctx, logger, request.Tag, request.LivenessCheckThreshold)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to check node liveness: %w", err)
+		return nil, fmt.Errorf("failed to check node liveness: %w", err)
 	}
 
 	return &LivenessCheckResponse{
@@ -90,16 +90,16 @@ func (a *LivenessCheck) checkLiveness(
 ) (bool, error) {
 	canonicalChainTipHeight, err := a.masterBlockchainClient.GetLatestHeight(ctx)
 	if err != nil {
-		return false, xerrors.Errorf("failed to get canonical chain tip height: %w", err)
+		return false, fmt.Errorf("failed to get canonical chain tip height: %w", err)
 	}
 
 	blocks, err := a.masterBlockchainClient.BatchGetBlockMetadata(ctx, tag, canonicalChainTipHeight, canonicalChainTipHeight+1)
 	if err != nil {
-		return false, xerrors.Errorf("failed to get latest block metadata for block=%d: %w", canonicalChainTipHeight, err)
+		return false, fmt.Errorf("failed to get latest block metadata for block=%d: %w", canonicalChainTipHeight, err)
 	}
 
 	if len(blocks) != 1 {
-		return false, xerrors.Errorf("unexpected block metadata length, actual=%d: %w", len(blocks), err)
+		return false, fmt.Errorf("unexpected block metadata length, actual=%d: %w", len(blocks), err)
 	}
 
 	violation := false

--- a/internal/workflow/activity/liveness_check_test.go
+++ b/internal/workflow/activity/liveness_check_test.go
@@ -2,6 +2,7 @@ package activity
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -10,7 +11,6 @@ import (
 	"go.uber.org/fx"
 	"go.uber.org/mock/gomock"
 	"go.uber.org/zap"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/blockchain/client"
 	clientmocks "github.com/coinbase/chainstorage/internal/blockchain/client/mocks"
@@ -167,7 +167,7 @@ func (s *LivenessCheckTestSuite) TestLivenessCheck_Failure() {
 
 	s.masterBlockchainClient.EXPECT().
 		GetLatestHeight(gomock.Any()).
-		Return(uint64(0), xerrors.Errorf("master client failure"))
+		Return(uint64(0), fmt.Errorf("master client failure"))
 
 	request := &LivenessCheckRequest{
 		Tag:                    tag,

--- a/internal/workflow/activity/loader.go
+++ b/internal/workflow/activity/loader.go
@@ -2,11 +2,11 @@ package activity
 
 import (
 	"context"
+	"fmt"
 
 	"go.temporal.io/sdk/workflow"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/cadence"
 	"github.com/coinbase/chainstorage/internal/storage/metastorage"
@@ -58,7 +58,7 @@ func (a *Loader) execute(ctx context.Context, request *LoaderRequest) (*LoaderRe
 	logger := a.getLogger(ctx)
 
 	if err := a.metaStorage.PersistBlockMetas(ctx, request.UpdateWatermark, request.Metadata, request.LastBlock); err != nil {
-		return nil, xerrors.Errorf("failed to persist blockMetadata: %w", err)
+		return nil, fmt.Errorf("failed to persist blockMetadata: %w", err)
 	}
 
 	response := &LoaderResponse{}

--- a/internal/workflow/activity/reader.go
+++ b/internal/workflow/activity/reader.go
@@ -2,10 +2,11 @@ package activity
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"go.temporal.io/sdk/workflow"
 	"go.uber.org/fx"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/cadence"
 	"github.com/coinbase/chainstorage/internal/storage"
@@ -59,13 +60,13 @@ func (a *Reader) execute(ctx context.Context, request *ReaderRequest) (*ReaderRe
 
 	metadata, err := a.readBlock(ctx, request)
 	if err != nil {
-		if xerrors.Is(err, storage.ErrItemNotFound) {
+		if errors.Is(err, storage.ErrItemNotFound) {
 			// Convert not-found error into an empty response.
 			// If the block has not been processed previously, we will skip the continuous-chain validation.
 			return &ReaderResponse{}, nil
 		}
 
-		return nil, xerrors.Errorf("failed to read block: %w", err)
+		return nil, fmt.Errorf("failed to read block: %w", err)
 	}
 
 	return &ReaderResponse{

--- a/internal/workflow/activity/validator_test.go
+++ b/internal/workflow/activity/validator_test.go
@@ -2,9 +2,8 @@ package activity
 
 import (
 	"context"
+	"fmt"
 	"testing"
-
-	"golang.org/x/xerrors"
 
 	"github.com/stretchr/testify/suite"
 	"go.temporal.io/sdk/testsuite"
@@ -432,7 +431,7 @@ func (s *ValidatorTestSuite) TestValidator_BlockValidation_Failure() {
 			AnyTimes()
 		s.parser.EXPECT().
 			ValidateBlock(gomock.Any(), gomock.Any()).
-			Return(xerrors.Errorf("mock error"))
+			Return(fmt.Errorf("mock error"))
 	}
 	s.slaveClient.EXPECT().
 		BatchGetBlockMetadata(gomock.Any(), blockTag, startHeight, endHeight+1).

--- a/internal/workflow/backfiller_test.go
+++ b/internal/workflow/backfiller_test.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"sync"
@@ -12,7 +13,6 @@ import (
 	"go.temporal.io/sdk/testsuite"
 	"go.uber.org/fx"
 	"go.uber.org/mock/gomock"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/blockchain/client"
 	clientmocks "github.com/coinbase/chainstorage/internal/blockchain/client/mocks"
@@ -489,7 +489,7 @@ func (s *backfillerTestSuite) TestBackfiller_Reprocess() {
 			if request.Heights[0] == blockNumber {
 				numCallsForReprocessedBlock += 1
 				if numCallsForReprocessedBlock <= maximumAttempts+1 {
-					return nil, xerrors.New("transient error")
+					return nil, errors.New("transient error")
 				}
 
 				require.True(request.WithBestEffort)

--- a/internal/workflow/benchmarker.go
+++ b/internal/workflow/benchmarker.go
@@ -10,7 +10,6 @@ import (
 	"go.temporal.io/sdk/workflow"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/cadence"
 	"github.com/coinbase/chainstorage/internal/config"
@@ -71,7 +70,7 @@ func (b *Benchmarker) execute(ctx workflow.Context, request *BenchmarkerRequest)
 
 	var cfg config.BenchmarkerWorkflowConfig
 	if err := b.readConfig(ctx, &cfg); err != nil {
-		return xerrors.Errorf("failed to read config: %w", err)
+		return fmt.Errorf("failed to read config: %w", err)
 	}
 
 	logger := b.getLogger(ctx).With(

--- a/internal/workflow/monitor.go
+++ b/internal/workflow/monitor.go
@@ -11,7 +11,6 @@ import (
 	"go.temporal.io/sdk/workflow"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/cadence"
 	"github.com/coinbase/chainstorage/internal/config"
@@ -87,7 +86,7 @@ func (w *Monitor) execute(ctx workflow.Context, request *MonitorRequest) error {
 	return w.executeWorkflow(ctx, request, func() error {
 		var cfg config.MonitorWorkflowConfig
 		if err := w.readConfig(ctx, &cfg); err != nil {
-			return xerrors.Errorf("failed to read config: %w", err)
+			return fmt.Errorf("failed to read config: %w", err)
 		}
 
 		logger := w.getLogger(ctx).With(
@@ -125,7 +124,7 @@ func (w *Monitor) execute(ctx workflow.Context, request *MonitorRequest) error {
 		if request.BackoffInterval != "" {
 			backoffInterval, err = time.ParseDuration(request.BackoffInterval)
 			if err != nil {
-				return xerrors.Errorf("failed to parse BackoffInterval=%v: %w", request.BackoffInterval, err)
+				return fmt.Errorf("failed to parse BackoffInterval=%v: %w", request.BackoffInterval, err)
 			}
 		}
 		zeroBackoff := backoffInterval == 0
@@ -184,7 +183,7 @@ func (w *Monitor) execute(ctx workflow.Context, request *MonitorRequest) error {
 					return w.continueAsNew(ctx, request)
 				}
 
-				return xerrors.Errorf("failed to execute validator: %w", err)
+				return fmt.Errorf("failed to execute validator: %w", err)
 			}
 			logger.Info("validated blocks", zap.Reflect("response", validatorResponse))
 			lastValidatedHeight := validatorResponse.LastValidatedHeight
@@ -221,7 +220,7 @@ func (w *Monitor) execute(ctx workflow.Context, request *MonitorRequest) error {
 
 			if !zeroBackoff {
 				if err := backoff.Get(ctx, nil); err != nil {
-					return xerrors.Errorf("failed to sleep: %w", err)
+					return fmt.Errorf("failed to sleep: %w", err)
 				}
 			}
 		}

--- a/internal/workflow/monitor_test.go
+++ b/internal/workflow/monitor_test.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 
@@ -9,7 +10,6 @@ import (
 	"go.temporal.io/sdk/testsuite"
 	"go.uber.org/fx"
 	"go.uber.org/mock/gomock"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/blockchain/client"
 	clientmocks "github.com/coinbase/chainstorage/internal/blockchain/client/mocks"
@@ -325,7 +325,7 @@ func (s *monitorTestSuite) TestMonitor_AutomatedTriggerFailover() {
 	s.cfg.Workflows.Monitor.FailoverEnabled = true
 	s.masterClient.EXPECT().GetLatestHeight(gomock.Any()).AnyTimes().
 		DoAndReturn(func(ctx context.Context) (uint64, error) {
-			return 0, xerrors.New("received http error: HTTPError 503")
+			return 0, errors.New("received http error: HTTPError 503")
 		})
 
 	s.env.ExecuteWorkflow(s.monitor.execute, &MonitorRequest{
@@ -442,7 +442,7 @@ func (s *monitorTestSuite) getMockBlock(height uint64, tag uint32) *api.Block {
 					   ],
 					   "transactionsRoot":"0x4513310fcb9f6f616972a3b948dc5d547f280849a87ebb5af0191f98b87be598",
 					   "uncles":[
-						  
+
 					   ]
 					}
 				`),
@@ -456,7 +456,7 @@ func (s *monitorTestSuite) getMockBlock(height uint64, tag uint32) *api.Block {
 						   "from":"0xa1e4380a3b1f749673e270229993ee55f35663b4",
 						   "gasUsed":"0x5208",
 						   "logs":[
-							  
+
 						   ],
 						   "logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
 						   "root":"0x96a8e009d2b88b1483e6941e6812e32263b05683fac202abc622a3e31aed1957",

--- a/internal/workflow/replicator.go
+++ b/internal/workflow/replicator.go
@@ -2,13 +2,13 @@ package workflow
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/workflow"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/cadence"
 	"github.com/coinbase/chainstorage/internal/config"
@@ -79,7 +79,7 @@ func (w *Replicator) execute(ctx workflow.Context, request *ReplicatorRequest) e
 
 		var cfg config.ReplicatorWorkflowConfig
 		if err := w.readConfig(ctx, &cfg); err != nil {
-			return xerrors.Errorf("failed to read config: %w", err)
+			return fmt.Errorf("failed to read config: %w", err)
 		}
 
 		batchSize := cfg.BatchSize
@@ -108,7 +108,7 @@ func (w *Replicator) execute(ctx workflow.Context, request *ReplicatorRequest) e
 		if request.DataCompression != "" {
 			dataCompression, err = utils.ParseCompression(request.DataCompression)
 			if err != nil {
-				return xerrors.Errorf("failed to parse data compression: %w", err)
+				return fmt.Errorf("failed to parse data compression: %w", err)
 			}
 		}
 
@@ -200,7 +200,7 @@ func (w *Replicator) execute(ctx workflow.Context, request *ReplicatorRequest) e
 					Compression: dataCompression,
 				})
 				if err != nil {
-					return xerrors.Errorf("failed to replicate block from %d to %d: %w", batchStart, batchEnd, err)
+					return fmt.Errorf("failed to replicate block from %d to %d: %w", batchStart, batchEnd, err)
 				}
 			}
 
@@ -212,7 +212,7 @@ func (w *Replicator) execute(ctx workflow.Context, request *ReplicatorRequest) e
 					BlockHeight:   endHeight - 1,
 				})
 				if err != nil {
-					return xerrors.Errorf("failed to update watermark: %w", err)
+					return fmt.Errorf("failed to update watermark: %w", err)
 				}
 			}
 		}

--- a/internal/workflow/streamer.go
+++ b/internal/workflow/streamer.go
@@ -10,7 +10,6 @@ import (
 	"go.temporal.io/sdk/workflow"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/cadence"
 	"github.com/coinbase/chainstorage/internal/config"
@@ -77,7 +76,7 @@ func (w *Streamer) execute(ctx workflow.Context, request *StreamerRequest) error
 	return w.executeWorkflow(ctx, request, func() error {
 		var cfg config.StreamerWorkflowConfig
 		if err := w.readConfig(ctx, &cfg); err != nil {
-			return xerrors.Errorf("failed to read config: %w", err)
+			return fmt.Errorf("failed to read config: %w", err)
 		}
 
 		logger := w.getLogger(ctx).With(
@@ -100,7 +99,7 @@ func (w *Streamer) execute(ctx workflow.Context, request *StreamerRequest) error
 		if request.BackoffInterval != "" {
 			backoffInterval, err = time.ParseDuration(request.BackoffInterval)
 			if err != nil {
-				return xerrors.Errorf("failed to parse BackoffInterval=%v: %w", request.BackoffInterval, err)
+				return fmt.Errorf("failed to parse BackoffInterval=%v: %w", request.BackoffInterval, err)
 			}
 		}
 		zeroBackoff := backoffInterval == 0
@@ -133,7 +132,7 @@ func (w *Streamer) execute(ctx workflow.Context, request *StreamerRequest) error
 			}
 			response, err := w.streamer.Execute(ctx, streamerRequest)
 			if err != nil {
-				return xerrors.Errorf("failed to execute streamer activity: %w", err)
+				return fmt.Errorf("failed to execute streamer activity: %w", err)
 			}
 			lastStreamedHeight := response.LatestStreamedHeight
 			metrics.Gauge(streamerHeightGauge).Update(float64(lastStreamedHeight))
@@ -146,7 +145,7 @@ func (w *Streamer) execute(ctx workflow.Context, request *StreamerRequest) error
 
 			if !zeroBackoff {
 				if err := backoff.Get(ctx, nil); err != nil {
-					return xerrors.Errorf("failed to sleep: %w", err)
+					return fmt.Errorf("failed to sleep: %w", err)
 				}
 			}
 		}

--- a/internal/workflow/workflow.go
+++ b/internal/workflow/workflow.go
@@ -15,7 +15,6 @@ import (
 	"go.temporal.io/sdk/workflow"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/cadence"
 	"github.com/coinbase/chainstorage/internal/config"
@@ -111,7 +110,7 @@ func (m *Manager) onStart(ctx context.Context) error {
 	)
 
 	if err := m.runtime.OnStart(ctx); err != nil {
-		return xerrors.Errorf("failed to start runtime: %w", err)
+		return fmt.Errorf("failed to start runtime: %w", err)
 	}
 
 	return nil
@@ -121,7 +120,7 @@ func (m *Manager) onStop(ctx context.Context) error {
 	m.logger.Info("stopping workflow manager")
 
 	if err := m.runtime.OnStop(ctx); err != nil {
-		return xerrors.Errorf("failed to stop runtime: %w", err)
+		return fmt.Errorf("failed to stop runtime: %w", err)
 	}
 
 	return nil
@@ -151,7 +150,7 @@ func (w *baseWorkflow) validateRequest(request any) error {
 
 func (w *baseWorkflow) validateRequestCtx(ctx context.Context, request any) error {
 	if err := w.validate.StructCtx(ctx, request); err != nil {
-		return xerrors.Errorf("invalid workflow request (name=%v, request=%+v): %w", w.name, request, err)
+		return fmt.Errorf("invalid workflow request (name=%v, request=%+v): %w", w.name, request, err)
 	}
 
 	return nil
@@ -174,7 +173,7 @@ func (w *baseWorkflow) startWorkflow(ctx context.Context, workflowID string, req
 
 	execution, err := w.runtime.ExecuteWorkflow(ctx, workflowOptions, w.name, request)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to execute workflow: %w", err)
+		return nil, fmt.Errorf("failed to execute workflow: %w", err)
 	}
 
 	return execution, nil
@@ -210,7 +209,7 @@ func (w *baseWorkflow) executeWorkflow(ctx workflow.Context, request any, fn ins
 		}
 
 		if err := fn(); err != nil {
-			return xerrors.Errorf("failed to execute workflow (name=%v): %w", w.name, err)
+			return fmt.Errorf("failed to execute workflow (name=%v): %w", w.name, err)
 		}
 
 		return nil
@@ -219,7 +218,7 @@ func (w *baseWorkflow) executeWorkflow(ctx workflow.Context, request any, fn ins
 
 func (w *baseWorkflow) StopWorkflow(ctx context.Context, workflowID string, reason string) error {
 	if err := w.runtime.TerminateWorkflow(ctx, workflowID, "", reason); err != nil {
-		return xerrors.Errorf("failed to terminate workflowID=%s: %w", workflowID, err)
+		return fmt.Errorf("failed to terminate workflowID=%s: %w", workflowID, err)
 	}
 
 	return nil
@@ -233,7 +232,7 @@ func (w *baseWorkflow) readConfig(ctx workflow.Context, output any) error {
 	})
 
 	if err := val.Get(output); err != nil {
-		return xerrors.Errorf("failed to retrieve config: %w", err)
+		return fmt.Errorf("failed to retrieve config: %w", err)
 	}
 
 	return nil

--- a/internal/workflow/workflow_identity.go
+++ b/internal/workflow/workflow_identity.go
@@ -2,9 +2,8 @@ package workflow
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
-
-	"golang.org/x/xerrors"
 )
 
 type WorkflowIdentity int
@@ -50,7 +49,7 @@ func GetWorkflowIdentify(name string) WorkflowIdentity {
 func (w WorkflowIdentity) String() (string, error) {
 	workflowIdentityString, ok := workflowIdentityToString[w]
 	if !ok {
-		return "", xerrors.Errorf("unsupported workflow identity: %v", w)
+		return "", fmt.Errorf("unsupported workflow identity: %v", w)
 	}
 	return workflowIdentityString, nil
 }
@@ -106,7 +105,7 @@ func (w WorkflowIdentity) UnmarshalJsonStringToRequest(str string) (any, error) 
 			return req, nil
 		}
 	default:
-		err = xerrors.Errorf("unsupported workflow identity: %v", w)
+		err = fmt.Errorf("unsupported workflow identity: %v", w)
 	}
 	return nil, err
 }

--- a/internal/workflow/workflow_test.go
+++ b/internal/workflow/workflow_test.go
@@ -1,6 +1,7 @@
 package workflow
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -9,10 +10,9 @@ import (
 	"go.temporal.io/api/failure/v1"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/utils/testutil"
-	"github.com/coinbase/chainstorage/internal/workflow/activity/errors"
+	workflowerrors "github.com/coinbase/chainstorage/internal/workflow/activity/errors"
 )
 
 type (
@@ -61,8 +61,8 @@ func TestIsErrSessionFailed(t *testing.T) {
 	activityErr := &activityError{
 		cause: temporal.NewApplicationError(workflow.ErrSessionFailed.Error(), ""),
 	}
-	err := xerrors.Errorf("fake activity error: %w", activityErr)
-	require.False(xerrors.Is(err, workflow.ErrSessionFailed))
+	err := fmt.Errorf("fake activity error: %w", activityErr)
+	require.False(errors.Is(err, workflow.ErrSessionFailed))
 	require.True(IsErrSessionFailed(nil, err))
 }
 
@@ -80,14 +80,14 @@ func TestIsNodeProviderFailed(t *testing.T) {
 	require := testutil.Require(t)
 
 	activityErr := &activityError{
-		cause: temporal.NewApplicationError(xerrors.New("Error Test").Error(), errors.ErrTypeNodeProvider),
+		cause: temporal.NewApplicationError(errors.New("Error Test").Error(), workflowerrors.ErrTypeNodeProvider),
 	}
-	err := xerrors.Errorf("fake activity error: %w", activityErr)
+	err := fmt.Errorf("fake activity error: %w", activityErr)
 	require.True(IsNodeProviderFailed(err))
 
 	activityErr = &activityError{
-		cause: temporal.NewApplicationError(xerrors.New("Error Test").Error(), xerrors.New("Random Error").Error()),
+		cause: temporal.NewApplicationError(errors.New("Error Test").Error(), errors.New("Random Error").Error()),
 	}
-	err = xerrors.Errorf("fake activity error: %w", activityErr)
+	err = fmt.Errorf("fake activity error: %w", activityErr)
 	require.False(IsNodeProviderFailed(err))
 }

--- a/protos/coinbase/crypto/rosetta/types/rosetta_converter.go
+++ b/protos/coinbase/crypto/rosetta/types/rosetta_converter.go
@@ -1,7 +1,7 @@
 package types
 
 import (
-	"golang.org/x/xerrors"
+	"fmt"
 
 	sdk "github.com/coinbase/rosetta-sdk-go/types"
 	anypb "google.golang.org/protobuf/types/known/anypb"
@@ -36,11 +36,11 @@ var (
 // FromSDKBlock converts Block from rosetta sdk type to proto type
 func FromSDKBlock(block *sdk.Block) (*Block, error) {
 	if block == nil {
-		return nil, xerrors.Errorf("block is nil")
+		return nil, fmt.Errorf("block is nil")
 	}
 
 	if block.BlockIdentifier == nil || block.ParentBlockIdentifier == nil {
-		return nil, xerrors.Errorf("missing required fields BlockIdentifier or ParentBlockIdentifier")
+		return nil, fmt.Errorf("missing required fields BlockIdentifier or ParentBlockIdentifier")
 	}
 
 	blockIdentifier := FromSDKBlockIdentifier(block.BlockIdentifier)
@@ -50,12 +50,12 @@ func FromSDKBlock(block *sdk.Block) (*Block, error) {
 
 	transactions, err := FromSDKTransactions(block.Transactions)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse transactions for block %v: %w", blockIndex, err)
+		return nil, fmt.Errorf("failed to parse transactions for block %v: %w", blockIndex, err)
 	}
 
 	blockMetadata, err := FromSDKMetadata(block.Metadata)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse block metadata for block %v: %w", blockIndex, err)
+		return nil, fmt.Errorf("failed to parse block metadata for block %v: %w", blockIndex, err)
 	}
 
 	return &Block{
@@ -73,7 +73,7 @@ func FromSDKBlocks(blocks []*sdk.Block) ([]*Block, error) {
 	for _, block := range blocks {
 		protoBlock, err := FromSDKBlock(block)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to parse block: %w", err)
+			return nil, fmt.Errorf("failed to parse block: %w", err)
 		}
 		result = append(result, protoBlock)
 	}
@@ -99,24 +99,24 @@ func FromSDKTransaction(transaction *sdk.Transaction) (*Transaction, error) {
 	}
 
 	if transaction.TransactionIdentifier == nil {
-		return nil, xerrors.Errorf("missing transaction identifier")
+		return nil, fmt.Errorf("missing transaction identifier")
 	}
 
 	transactionHash := transaction.TransactionIdentifier.Hash
 
 	operations, err := FromSDKOperations(transaction.Operations)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse transaction operations transactionHash=%v: %w", transactionHash, err)
+		return nil, fmt.Errorf("failed to parse transaction operations transactionHash=%v: %w", transactionHash, err)
 	}
 
 	relatedTransactions, err := FromSDKRelatedTransactions(transaction.RelatedTransactions)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse transaction relatedTransactions transactionHash=%v: %w", transactionHash, err)
+		return nil, fmt.Errorf("failed to parse transaction relatedTransactions transactionHash=%v: %w", transactionHash, err)
 	}
 
 	metadata, err := FromSDKMetadata(transaction.Metadata)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse transaction metadata transactionHash=%v: %w", transactionHash, err)
+		return nil, fmt.Errorf("failed to parse transaction metadata transactionHash=%v: %w", transactionHash, err)
 	}
 
 	return &Transaction{
@@ -135,7 +135,7 @@ func FromSDKTransactions(transactions []*sdk.Transaction) ([]*Transaction, error
 	for i, transaction := range transactions {
 		tx, err := FromSDKTransaction(transaction)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to parse transaction: %w", err)
+			return nil, fmt.Errorf("failed to parse transaction: %w", err)
 		}
 		result[i] = tx
 	}
@@ -149,12 +149,12 @@ func FromSDKRelatedTransaction(relatedTransaction *sdk.RelatedTransaction) (*Rel
 	}
 
 	if relatedTransaction.TransactionIdentifier == nil {
-		return nil, xerrors.Errorf("missing TransactionIdentifier of related transaction")
+		return nil, fmt.Errorf("missing TransactionIdentifier of related transaction")
 	}
 
 	networkIdentifier, err := FromSDKNetworkIdentifier(relatedTransaction.NetworkIdentifier)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse networkIdentifier: %w", err)
+		return nil, fmt.Errorf("failed to parse networkIdentifier: %w", err)
 	}
 
 	return &RelatedTransaction{
@@ -172,7 +172,7 @@ func FromSDKRelatedTransactions(relatedTransactions []*sdk.RelatedTransaction) (
 	for i, transaction := range relatedTransactions {
 		tx, err := FromSDKRelatedTransaction(transaction)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to parse related transaction: %w", err)
+			return nil, fmt.Errorf("failed to parse related transaction: %w", err)
 		}
 		result[i] = tx
 	}
@@ -188,7 +188,7 @@ func FromSDKSubNetworkIdentifier(subNetworkIdentifier *sdk.SubNetworkIdentifier)
 
 	subNetworkMetadata, err := FromSDKMetadata(subNetworkIdentifier.Metadata)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse subNetworkIdentifier metadata: %w", err)
+		return nil, fmt.Errorf("failed to parse subNetworkIdentifier metadata: %w", err)
 	}
 
 	return &SubNetworkIdentifier{
@@ -205,7 +205,7 @@ func FromSDKNetworkIdentifier(networkIdentifier *sdk.NetworkIdentifier) (*Networ
 
 	subNetworkIdentifier, err := FromSDKSubNetworkIdentifier(networkIdentifier.SubNetworkIdentifier)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse subNetworkIdentifier: %w", err)
+		return nil, fmt.Errorf("failed to parse subNetworkIdentifier: %w", err)
 	}
 
 	return &NetworkIdentifier{
@@ -226,19 +226,19 @@ func FromSDKOperation(operation *sdk.Operation) (*Operation, error) {
 
 	account, err := FromSDKAccountIdentifier(operation.Account)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse operation account: %w", err)
+		return nil, fmt.Errorf("failed to parse operation account: %w", err)
 	}
 
 	amount, err := FromSDKAmount(operation.Amount)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse operation amount: %w", err)
+		return nil, fmt.Errorf("failed to parse operation amount: %w", err)
 	}
 
 	coinChange := FromSDKCoinChange(operation.CoinChange)
 
 	metadata, err := FromSDKMetadata(operation.Metadata)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse operation metadata: %w", err)
+		return nil, fmt.Errorf("failed to parse operation metadata: %w", err)
 	}
 
 	return &Operation{
@@ -259,7 +259,7 @@ func FromSDKOperations(operations []*sdk.Operation) ([]*Operation, error) {
 	for i, operation := range operations {
 		op, err := FromSDKOperation(operation)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to parse operation: %w", err)
+			return nil, fmt.Errorf("failed to parse operation: %w", err)
 		}
 		result[i] = op
 	}
@@ -295,12 +295,12 @@ func FromSDKAccountIdentifier(accountIdentifier *sdk.AccountIdentifier) (*Accoun
 
 	accountMetadata, err := FromSDKMetadata(accountIdentifier.Metadata)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse account metadata: %w", err)
+		return nil, fmt.Errorf("failed to parse account metadata: %w", err)
 	}
 
 	subAccount, err := FromSDKSubAccountIdentifier(accountIdentifier.SubAccount)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse subAccount: %w", err)
+		return nil, fmt.Errorf("failed to parse subAccount: %w", err)
 	}
 
 	return &AccountIdentifier{
@@ -318,7 +318,7 @@ func FromSDKSubAccountIdentifier(subAccountIdentifier *sdk.SubAccountIdentifier)
 
 	subAccountMetadata, err := FromSDKMetadata(subAccountIdentifier.Metadata)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse subAccount metadata: %w", err)
+		return nil, fmt.Errorf("failed to parse subAccount metadata: %w", err)
 	}
 	return &SubAccountIdentifier{
 		Address:  subAccountIdentifier.Address,
@@ -334,12 +334,12 @@ func FromSDKAmount(amount *sdk.Amount) (*Amount, error) {
 
 	amountMetadata, err := FromSDKMetadata(amount.Metadata)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse amount metadata: %w", err)
+		return nil, fmt.Errorf("failed to parse amount metadata: %w", err)
 	}
 
 	currency, err := FromSDKCurrency(amount.Currency)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse amount currency: %w", err)
+		return nil, fmt.Errorf("failed to parse amount currency: %w", err)
 	}
 
 	return &Amount{
@@ -357,7 +357,7 @@ func FromSDKCurrency(currency *sdk.Currency) (*Currency, error) {
 
 	metadata, err := FromSDKMetadata(currency.Metadata)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse currency metadata: %w", err)
+		return nil, fmt.Errorf("failed to parse currency metadata: %w", err)
 	}
 
 	return &Currency{
@@ -398,7 +398,7 @@ func FromSDKMetadata(metadata map[string]interface{}) (map[string]*anypb.Any, er
 	for k, v := range metadata {
 		value, err := MarshalToAny(v)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to marshal %v to Any: %w", v, err)
+			return nil, fmt.Errorf("failed to marshal %v to Any: %w", v, err)
 		}
 		result[k] = value
 	}
@@ -412,23 +412,23 @@ func ToSDKTransaction(transaction *Transaction) (*sdk.Transaction, error) {
 	}
 
 	if transaction.TransactionIdentifier == nil {
-		return nil, xerrors.Errorf("missing transaction identifier")
+		return nil, fmt.Errorf("missing transaction identifier")
 	}
 
 	transactionHash := transaction.GetTransactionIdentifier().GetHash()
 	operations, err := ToSDKOperations(transaction.Operations)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse transaction operations to sdk type transactionHash=%v: %w", transactionHash, err)
+		return nil, fmt.Errorf("failed to parse transaction operations to sdk type transactionHash=%v: %w", transactionHash, err)
 	}
 
 	relatedTransactions, err := ToSDKRelatedTransactions(transaction.RelatedTransactions)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse related transactions to sdk type transactionHash=%v: %w", transactionHash, err)
+		return nil, fmt.Errorf("failed to parse related transactions to sdk type transactionHash=%v: %w", transactionHash, err)
 	}
 
 	metadata, err := ToSDKMetadata(transaction.Metadata)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse transaction metadata to sdk type transactionHash=%v: %w", transactionHash, err)
+		return nil, fmt.Errorf("failed to parse transaction metadata to sdk type transactionHash=%v: %w", transactionHash, err)
 	}
 
 	return &sdk.Transaction{
@@ -447,7 +447,7 @@ func ToSDKOperations(operations []*Operation) ([]*sdk.Operation, error) {
 	for i, operation := range operations {
 		op, err := ToSDKOperation(operation)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to parse operation to sdk type: %w", err)
+			return nil, fmt.Errorf("failed to parse operation to sdk type: %w", err)
 		}
 		result[i] = op
 	}
@@ -460,7 +460,7 @@ func ToSDKRelatedTransactions(relatedTransactions []*RelatedTransaction) ([]*sdk
 	for i, transaction := range relatedTransactions {
 		tx, err := ToSDKRelatedTransaction(transaction)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to parse related transaction to sdk type: %w", err)
+			return nil, fmt.Errorf("failed to parse related transaction to sdk type: %w", err)
 		}
 		result[i] = tx
 	}
@@ -474,12 +474,12 @@ func ToSDKRelatedTransaction(relatedTransaction *RelatedTransaction) (*sdk.Relat
 	}
 
 	if relatedTransaction.TransactionIdentifier == nil {
-		return nil, xerrors.Errorf("missing TransactionIdentifier of related transaction")
+		return nil, fmt.Errorf("missing TransactionIdentifier of related transaction")
 	}
 
 	networkIdentifier, err := ToSDKNetworkIdentifier(relatedTransaction.NetworkIdentifier)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse networkIdentifier to sdk type: %w", err)
+		return nil, fmt.Errorf("failed to parse networkIdentifier to sdk type: %w", err)
 	}
 
 	return &sdk.RelatedTransaction{
@@ -499,7 +499,7 @@ func ToSDKSubNetworkIdentifier(subNetworkIdentifier *SubNetworkIdentifier) (*sdk
 
 	subNetworkMetadata, err := ToSDKMetadata(subNetworkIdentifier.Metadata)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse subNetworkIdentifier metadata to sdk type: %w", err)
+		return nil, fmt.Errorf("failed to parse subNetworkIdentifier metadata to sdk type: %w", err)
 	}
 
 	return &sdk.SubNetworkIdentifier{
@@ -516,7 +516,7 @@ func ToSDKNetworkIdentifier(networkIdentifier *NetworkIdentifier) (*sdk.NetworkI
 
 	subNetworkIdentifier, err := ToSDKSubNetworkIdentifier(networkIdentifier.SubNetworkIdentifier)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse subNetworkIdentifier to sdk type: %w", err)
+		return nil, fmt.Errorf("failed to parse subNetworkIdentifier to sdk type: %w", err)
 	}
 
 	return &sdk.NetworkIdentifier{
@@ -561,20 +561,20 @@ func ToSDKOperation(rosettaOp *Operation) (*sdk.Operation, error) {
 	}
 
 	if rosettaOp.OperationIdentifier == nil {
-		return nil, xerrors.Errorf("missing OperationIdentifier")
+		return nil, fmt.Errorf("missing OperationIdentifier")
 	}
 
 	account, err := ToSDKAccountIdentifier(rosettaOp.Account)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse account to sdk type: %w", err)
+		return nil, fmt.Errorf("failed to parse account to sdk type: %w", err)
 	}
 	amount, err := ToSDKAmount(rosettaOp.Amount)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse amount to sdk type: %w", err)
+		return nil, fmt.Errorf("failed to parse amount to sdk type: %w", err)
 	}
 	metadata, err := ToSDKMetadata(rosettaOp.Metadata)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse operation metadata to sdk type: %w", err)
+		return nil, fmt.Errorf("failed to parse operation metadata to sdk type: %w", err)
 	}
 
 	result := &sdk.Operation{
@@ -601,7 +601,7 @@ func ToSDKAccountIdentifier(account *AccountIdentifier) (*sdk.AccountIdentifier,
 	}
 	accountMetadata, err := ToSDKMetadata(account.Metadata)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse account metadata %+v: %w", account.Metadata, err)
+		return nil, fmt.Errorf("failed to parse account metadata %+v: %w", account.Metadata, err)
 	}
 	sdkAccount := &sdk.AccountIdentifier{
 		Address:  account.Address,
@@ -611,7 +611,7 @@ func ToSDKAccountIdentifier(account *AccountIdentifier) (*sdk.AccountIdentifier,
 	if subAccount != nil {
 		subAccountMetadata, err := ToSDKMetadata(subAccount.Metadata)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to parse subAccount metadata %+v: %w", subAccount.Metadata, err)
+			return nil, fmt.Errorf("failed to parse subAccount metadata %+v: %w", subAccount.Metadata, err)
 		}
 		sdkAccount.SubAccount = &sdk.SubAccountIdentifier{
 			Address:  subAccount.Address,
@@ -628,7 +628,7 @@ func ToSDKAmount(amount *Amount) (*sdk.Amount, error) {
 	}
 	amountMetadata, err := ToSDKMetadata(amount.Metadata)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to parse amount metadata %+v: %w", amount.Metadata, err)
+		return nil, fmt.Errorf("failed to parse amount metadata %+v: %w", amount.Metadata, err)
 	}
 
 	sdkAmount := &sdk.Amount{
@@ -639,7 +639,7 @@ func ToSDKAmount(amount *Amount) (*sdk.Amount, error) {
 	if amountCurrency != nil {
 		currencyMetadata, err := ToSDKMetadata(amountCurrency.Metadata)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to parse amount currency metadata %+v: %w", amountCurrency.Metadata, err)
+			return nil, fmt.Errorf("failed to parse amount currency metadata %+v: %w", amountCurrency.Metadata, err)
 		}
 		sdkAmount.Currency = &sdk.Currency{
 			Symbol:   amountCurrency.Symbol,
@@ -656,7 +656,7 @@ func ToSDKMetadata(metadata map[string]*anypb.Any) (map[string]interface{}, erro
 	for k, v := range metadata {
 		value, err := UnmarshalToInterface(v)
 		if err != nil {
-			return nil, xerrors.Errorf("unable to unmarshal proto value %+v to a generic Go interface", v)
+			return nil, fmt.Errorf("unable to unmarshal proto value %+v to a generic Go interface", v)
 		}
 		result[k] = value
 	}

--- a/protos/coinbase/crypto/rosetta/types/utils.go
+++ b/protos/coinbase/crypto/rosetta/types/utils.go
@@ -1,7 +1,8 @@
 package types
 
 import (
-	"golang.org/x/xerrors"
+	"fmt"
+
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -47,12 +48,12 @@ func ConvertMillisecondsToTimestamp(milliseconds int64) *timestamppb.Timestamp {
 func MarshalToAny(v interface{}) (*anypb.Any, error) {
 	pv, err := structpb.NewValue(v)
 	if err != nil {
-		return nil, xerrors.Errorf("%v cannot convert to structpb.Value: %w", v, err)
+		return nil, fmt.Errorf("%v cannot convert to structpb.Value: %w", v, err)
 	}
 
 	value, err := anypb.New(pv)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to marshal into Any for %v: %w", pv, err)
+		return nil, fmt.Errorf("failed to marshal into Any for %v: %w", pv, err)
 	}
 
 	return value, nil

--- a/sdk/client_interceptor.go
+++ b/sdk/client_interceptor.go
@@ -2,10 +2,10 @@ package sdk
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"go.uber.org/zap"
-	"golang.org/x/xerrors"
 	"google.golang.org/grpc/codes"
 
 	"github.com/coinbase/chainstorage/internal/gateway"
@@ -187,12 +187,12 @@ func intercept[T any](ctx context.Context, logger *zap.Logger, operation retry.O
 }
 
 func isRetryableError(err error) bool {
-	if xerrors.Is(err, context.DeadlineExceeded) {
+	if errors.Is(err, context.DeadlineExceeded) {
 		return true
 	}
 
 	var grpcErr gateway.GrpcError
-	if xerrors.As(err, &grpcErr) && grpcErr.GRPCStatus().Code() == codes.DeadlineExceeded {
+	if errors.As(err, &grpcErr) && grpcErr.GRPCStatus().Code() == codes.DeadlineExceeded {
 		return true
 	}
 

--- a/sdk/client_test.go
+++ b/sdk/client_test.go
@@ -2,13 +2,13 @@ package sdk
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/fx"
 	"go.uber.org/mock/gomock"
-	"golang.org/x/xerrors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -319,7 +319,7 @@ func (s *clientTestSuite) TestStreamBlocks_WithSkippedBlocks() {
 }
 
 func (s *clientTestSuite) TestStreamBlocks_ErrStreamChainEvents() {
-	mockError := xerrors.New("some mock error")
+	mockError := errors.New("some mock error")
 	s.gatewayClient.EXPECT().StreamChainEvents(gomock.Any(), gomock.Any()).Return(nil, mockError)
 	ch, err := s.client.StreamChainEvents(context.Background(), StreamingConfiguration{
 		ChainEventsRequest: &api.ChainEventsRequest{},
@@ -334,7 +334,7 @@ func (s *clientTestSuite) TestStreamBlocks_ErrStreamChainEvents() {
 }
 
 func (s *clientTestSuite) TestStreamBlocks_ErrRecv() {
-	mockError := xerrors.New("some mock error")
+	mockError := errors.New("some mock error")
 	s.gatewayClient.EXPECT().StreamChainEvents(gomock.Any(), gomock.Any()).Return(s.streamClient, nil)
 	s.streamClient.EXPECT().Recv().Return(nil, mockError)
 
@@ -432,7 +432,7 @@ func (s *clientTestSuite) TestStreamBlocks_RecvPermanentErr() {
 		})).Return(s.streamClient, nil),
 		s.gatewayClient.EXPECT().StreamChainEvents(gomock.Any(), testutil.MatchProto(&api.ChainEventsRequest{
 			SequenceNum: 109,
-		})).Return(s.streamClient, xerrors.New("some mock error")),
+		})).Return(s.streamClient, errors.New("some mock error")),
 	)
 	s.gatewayClient.EXPECT().GetBlockFile(gomock.Any(), gomock.Any()).Return(&api.GetBlockFileResponse{}, nil).AnyTimes()
 	s.downloaderClient.EXPECT().Download(gomock.Any(), gomock.Any()).Return(&api.Block{}, nil).AnyTimes()

--- a/sdk/session.go
+++ b/sdk/session.go
@@ -1,10 +1,11 @@
 package sdk
 
 import (
+	"fmt"
+
 	"github.com/uber-go/tally/v4"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
-	"golang.org/x/xerrors"
 
 	"github.com/coinbase/chainstorage/internal/blockchain/parser"
 	"github.com/coinbase/chainstorage/internal/config"
@@ -35,7 +36,7 @@ type (
 
 func New(manager services.SystemManager, cfg *Config) (Session, error) {
 	if err := cfg.validate(); err != nil {
-		return nil, xerrors.Errorf("invalid config %+v: %w", cfg, err)
+		return nil, fmt.Errorf("invalid config %+v: %w", cfg, err)
 	}
 
 	internalCfg, err := config.New(
@@ -45,7 +46,7 @@ func New(manager services.SystemManager, cfg *Config) (Session, error) {
 		config.WithSidechain(cfg.Sidechain),
 	)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to create config %w", err)
+		return nil, fmt.Errorf("failed to create config %w", err)
 	}
 
 	var session Session
@@ -65,7 +66,7 @@ func New(manager services.SystemManager, cfg *Config) (Session, error) {
 		fx.Populate(&session),
 	)
 	if err := app.Start(manager.Context()); err != nil {
-		return nil, xerrors.Errorf("failed to start fx app: %w", err)
+		return nil, fmt.Errorf("failed to start fx app: %w", err)
 	}
 
 	manager.AddPreShutdownHook(func() {


### PR DESCRIPTION
### What changed? Why?

Removed the dependency on `golang.org/x/xerrors` throughout the codebase and refactored error handling to use the standard `fmt.Errorf` function  with the `%w` verb for error wrapping, in combination with Go's built-in  `errors` package for unwrapping and type assertion.

> There were 3 errors incorrectly formatted. Now that standard packages are used, `go vet` can detect them easily.

#### Why xerrors is no longer needed

Since Go 1.13, the language has supported native error wrapping with `fmt.Errorf("...: %w", err)`, and since Go 1.20, the built-in error handling tools are mature enough to fully replace `xerrors`. The key improvements include:

- **Native error wrapping**: `fmt.Errorf` with `%w` wraps errors effectively, allowing use of `errors.Is` and `errors.As` to inspect wrapped errors, matching the functionality `xerrors` previously offered.
- **Improved error formatting**: Go 1.20 enhances error formatting, providing multi-line stack traces with `%+v` when needed, eliminating the need  for `xerrors`' custom formatting.
- **Simplified dependencies**: Removing `xerrors` reduces external dependencies, improving maintainability and compatibility with future Go updates.
- **Tooling**: Benefit from all the standard tooling (e.g. lint)
 
### How did you test the change?
- [x] unit test
- [ ] integration test
- [ ] functional test
- [ ] adhoc test (described below)